### PR TITLE
Fix build error

### DIFF
--- a/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
+++ b/modules/tinymce/src/core/test/ts/browser/EditorTest.ts
@@ -401,7 +401,7 @@ describe('browser.tinymce.core.EditorTest', () => {
     assert.isFalse(editor.isDirty(), 'setDirty/isDirty');
 
     editor.setDirty(true);
-    assert.equal(lastArgs?.type, 'dirty', 'setDirty/isDirty');
+    assert.equal((lastArgs as EditorEvent<{}> | undefined)?.type, 'dirty', 'setDirty/isDirty');
     assert.isTrue( editor.isDirty(), 'setDirty/isDirty');
 
     lastArgs = undefined;


### PR DESCRIPTION
Build was failing on
`Error: src/core/test/ts/browser/EditorTest.ts(404,28): error TS2339: Property 'type' does not exist on type 'never'.` so it was fixed by specifying the type of `lastArgs`.