### PR TITLE
Set editable div as content when the editor does not have an editable root and is empty

### DIFF
--- a/modules/tinymce/src/core/main/ts/delete/BlockRangeDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/BlockRangeDelete.ts
@@ -49,7 +49,11 @@ const isEverythingSelected = (root: SugarElement<Node>, rng: Range): boolean => 
 
 const emptyEditor = (editor: Editor): Optional<() => void> => {
   return Optional.some(() => {
-    editor.setContent('');
+    if (editor.hasEditableRoot()) {
+      editor.setContent('');
+    } else {
+      editor.setContent(`<div class=${editor.getParam('editable_class')}>${editor.getParam('placeholder')}</div>`);
+    }
     editor.selection.setCursorLocation();
   });
 };


### PR DESCRIPTION
In cases where the editor does not have an editable root (multi-root editing is on), deleting all content would also remove the editable element, leaving the editor without a focusable area. This update fixes the issue by checking if the editor has an editable root when the content is completely removed. If the editor does not have editable root and is empty, the editable element is automatically restored to maintain a functional editing environment.