### PR TITLE
Fix publish errors

### DIFF
--- a/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
+++ b/modules/bridge/src/main/ts/ephox/bridge/components/dialog/Label.ts
@@ -7,6 +7,7 @@ type Alignment = 'start' | 'center' | 'end';
 
 export interface LabelSpec {
   type: 'label';
+  name?: string;
   label: string;
   items: BodyComponentSpec[];
   align?: Alignment;

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
@@ -65,10 +65,12 @@ const children: Dialog.BodyComponentSpec[] = [
 const getItems = (editor: Editor): Dialog.BodyComponentSpec[] => {
   const inputs = Options.getTableCellInputs(editor).split(" ");
   const allItems = children.concat(getClassList(editor).toArray());
-  const filteredItems = allItems.filter((item) => inputs.includes(item.name));
-  return filteredItems.sort((a, b) => 
-    inputs.indexOf(a.name) - inputs.indexOf(b.name)
-  );
+  const filteredItems = allItems.filter((item) => 'name' in item && inputs.includes(item.name));
+  return filteredItems.sort((a, b) => {
+    const nameA = 'name' in a ? a.name : '';
+    const nameB = 'name' in b ? b.name : '';
+    return inputs.indexOf(nameA) - inputs.indexOf(nameB);
+  });
 }
 
 export {

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialogGeneralTab.ts
@@ -47,10 +47,12 @@ const formChildren: Dialog.BodyComponentSpec[] = [
 const getItems = (editor: Editor): Dialog.BodyComponentSpec[] => {
   const inputs = Options.getTableRowInputs(editor).split(" ");
   const allItems = formChildren.concat(getClassList(editor).toArray());
-  const filteredItems = allItems.filter((item) => inputs.includes(item.name));
-  return filteredItems.sort((a, b) => 
-    inputs.indexOf(a.name) - inputs.indexOf(b.name)
-  );
+  const filteredItems = allItems.filter((item) => 'name' in item && inputs.includes(item.name));
+  return filteredItems.sort((a, b) => {
+    const nameA = 'name' in a ? a.name : '';
+    const nameB = 'name' in b ? b.name : '';
+    return inputs.indexOf(nameA) - inputs.indexOf(nameB);
+  });
 }
 
 export {

--- a/modules/tinymce/src/plugins/table/main/ts/ui/TableDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/TableDialogGeneralTab.ts
@@ -82,10 +82,12 @@ const getItems = (editor: Editor, classes: Dialog.ListBoxItemSpec[], insertNewTa
   }
 
   const inputs = Options.getTableInputs(editor).split(" ");
-  const filteredTableSettingsItems = tableSettingsItems.filter((item) => inputs.includes(item.name))
-  const sortedItems = filteredTableSettingsItems.sort((a, b) => 
-    inputs.indexOf(a.name) - inputs.indexOf(b.name)
-  );
+  const filteredTableSettingsItems = tableSettingsItems.filter((item) => 'name' in item && inputs.includes(item.name));
+  const sortedItems = filteredTableSettingsItems.sort((a, b) => {
+    const nameA = 'name' in a ? a.name : '';
+    const nameB = 'name' in b ? b.name : '';
+    return inputs.indexOf(nameA) - inputs.indexOf(nameB);
+  });
   return rowColCountItems.concat(sortedItems);
 };
 


### PR DESCRIPTION
Publish workflow failed as the existing implementation assumes that all objects in the allItems array have a name property. However, some objects do not have this property, resulting in TypeScript errors (TS2339: Property 'name' does not exist) during filtering and sorting operations.

We use the `name` in item check to ensure the property exists before directly accessing the property.