### PR TITLE
Set minimum double border width to 3px

### DIFF
--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
@@ -60,8 +60,9 @@ const updateAdvancedProps = (modifier: DomModifier, data: Required<CellData>, sh
   if (shouldUpdate('borderstyle')) {
     modifier.setFormat('tablecellborderstyle', data.borderstyle);
   }
-  if (shouldUpdate('borderwidth')) {
-    modifier.setFormat('tablecellborderwidth', Utils.addPxSuffix(data.borderwidth));
+  if (shouldUpdate('borderwidth') || data.borderstyle === "double") {
+    const borderWidth = Helpers.getValidBorderWidth(data.borderwidth, data.borderstyle);
+    modifier.setFormat('tablecellborderwidth', Utils.addPxSuffix(borderWidth));
   }
 };
 

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
@@ -232,12 +232,22 @@ const extractDataFromCellElement = (editor: Editor, cell: HTMLTableCellElement, 
   };
 };
 
+const getValidBorderWidth = (borderWidth: string, borderStyle?: string): string => {
+  if (!borderStyle || borderStyle !== 'double') return borderWidth;
+  
+  const floatBorder = parseFloat(borderWidth);
+  const isValidDoubleBorderWidth = floatBorder !== undefined && (floatBorder === 0 || floatBorder >= 3);
+  
+  return isValidDoubleBorderWidth ? borderWidth : '3px';
+}
+
 export {
   extractAdvancedStyles,
   getSharedValues,
   extractDataFromTableElement,
   extractDataFromRowElement,
   extractDataFromCellElement,
-  extractDataFromSettings
+  extractDataFromSettings,
+  getValidBorderWidth
 };
 

--- a/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/TableDialog.ts
@@ -49,6 +49,7 @@ const applyDataToElement = (editor: Editor, tableElm: HTMLTableElement, data: Ta
   const shouldStyleWithCss = Options.shouldStyleWithCss(editor);
   const hasAdvancedTableTab = Options.hasAdvancedTableTab(editor);
   const borderIsZero = parseFloat(data.border) === 0;
+  const borderWidth = Helpers.getValidBorderWidth(data.border, data.borderstyle);
 
   if (!Type.isUndefined(data.class) && data.class !== 'mce-no-match') {
     attrs.class = data.class;
@@ -67,12 +68,12 @@ const applyDataToElement = (editor: Editor, tableElm: HTMLTableElement, data: Ta
       attrs.border = 0;
       styles['border-width'] = '';
     } else {
-      styles['border-width'] = Utils.addPxSuffix(data.border);
+      styles['border-width'] = Utils.addPxSuffix(borderWidth);
       attrs.border = 1;
     }
     styles['border-spacing'] = Utils.addPxSuffix(data.cellspacing);
   } else {
-    attrs.border = borderIsZero ? 0 : data.border;
+    attrs.border = borderIsZero ? 0 : borderWidth;
     attrs.cellpadding = data.cellpadding;
     attrs.cellspacing = data.cellspacing;
   }
@@ -83,7 +84,7 @@ const applyDataToElement = (editor: Editor, tableElm: HTMLTableElement, data: Ta
     if (borderIsZero) {
       cellStyles['border-width'] = '';
     } else if (shouldApplyOnCell.border) {
-      cellStyles['border-width'] = Utils.addPxSuffix(data.border);
+      cellStyles['border-width'] = Utils.addPxSuffix(borderWidth);
     }
     if (shouldApplyOnCell.cellpadding) {
       cellStyles.padding = Utils.addPxSuffix(data.cellpadding);


### PR DESCRIPTION
Previously, when the border width was set to 1px and the style changed to "double," the appearance remained unchanged due to the insufficient width required to properly render a double border. This update ensures that when the "double" border style is selected, if the width is either undefined or less than 3px, it will automatically be set to 3px to display the double border correctly. The exception is when the border width is 0px, which hides the border entirely and remains unaffected by this change to maintain consistent behavior across all border styles.