### PR TITLE
Do not prepend protocol to links that starts with #

### DIFF
--- a/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/core/Utils.ts
@@ -147,7 +147,7 @@ const getLinkAttrs = (data: LinkDialogOutput): LinkAttrs => {
 const handleExternalTargets = (href: string, assumeExternalTargets: AssumeExternalTargets): string => {
   if ((assumeExternalTargets === AssumeExternalTargets.ALWAYS_HTTP
         || assumeExternalTargets === AssumeExternalTargets.ALWAYS_HTTPS)
-      && !hasProtocol(href)) {
+      && !hasProtocol(href) && !href.startsWith('#')) {
     return assumeExternalTargets + '://' + href;
   }
   return href;

--- a/modules/tinymce/src/plugins/link/main/ts/ui/DialogConfirms.ts
+++ b/modules/tinymce/src/plugins/link/main/ts/ui/DialogConfirms.ts
@@ -37,7 +37,7 @@ const tryEmailTransform = (data: LinkDialogOutput): Optional<Transformer> => {
 const tryProtocolTransform = (assumeExternalTargets: AssumeExternalTargets, defaultLinkProtocol: string) => (data: LinkDialogOutput): Optional<Transformer> => {
   const url = data.href;
   const suggestProtocol = (
-    assumeExternalTargets === AssumeExternalTargets.WARN && !Utils.hasProtocol(url) ||
+    assumeExternalTargets === AssumeExternalTargets.WARN && !Utils.hasProtocol(url) && !url.startsWith('#') ||
     assumeExternalTargets === AssumeExternalTargets.OFF && /^\s*www(\.|\d\.)/i.test(url)
   );
 


### PR DESCRIPTION
**Issue:** When the anchors plugin was used in combination with the `link_assume_external_targets` option set to `http` or `https`, the specified protocol was being prepended to all links, including anchor links (e.g., `#id`).

**Fix:** This update introduces a condition to ensure that if a link starts with a `#`, the protocol will not be prepended.