### PR TITLE
Limit number of concurrent image uploads

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -237,6 +237,11 @@ const register = (editor: Editor): void => {
     processor: 'function'
   });
 
+  registerOption('images_upload_max_concurrent_uploads', {
+    processor: 'number',
+    default: 5
+  });
+
   registerOption('language', {
     processor: 'string',
     default: 'en'
@@ -902,6 +907,7 @@ const getImageUploadUrl = option('images_upload_url');
 const getImageUploadBasePath = option('images_upload_base_path');
 const getImagesUploadCredentials = option('images_upload_credentials');
 const getImagesUploadHandler = option('images_upload_handler');
+const getImagesUploadMaxConcurrentUploads = option('images_upload_max_concurrent_uploads');
 const shouldUseContentCssCors = option('content_css_cors');
 const getReferrerPolicy = option('referrer_policy');
 const getLanguageCode = option('language');
@@ -1015,6 +1021,7 @@ export {
   getImageUploadBasePath,
   getImagesUploadCredentials,
   getImagesUploadHandler,
+  getImagesUploadMaxConcurrentUploads,
   shouldUseContentCssCors,
   getReferrerPolicy,
   getLanguageCode,

--- a/modules/tinymce/src/core/main/ts/api/util/ImageUploader.ts
+++ b/modules/tinymce/src/core/main/ts/api/util/ImageUploader.ts
@@ -23,6 +23,7 @@ export const createUploader = (editor: Editor, uploadStatus: UploadStatus): Uplo
     url: Options.getImageUploadUrl(editor),
     basePath: Options.getImageUploadBasePath(editor),
     credentials: Options.getImagesUploadCredentials(editor),
+    maxConcurrentUploads: Options.getImagesUploadMaxConcurrentUploads(editor),
     handler: Options.getImagesUploadHandler(editor)
   });
 

--- a/modules/tinymce/src/core/main/ts/util/Queue.ts
+++ b/modules/tinymce/src/core/main/ts/util/Queue.ts
@@ -1,0 +1,8 @@
+export const concurrentQueue = async <Item, ReturnValue>(item: Item[], threads: number, fn: (item: Item, index: number, array: Item[]) => Promise<ReturnValue>) => {
+  let i = 0;
+  const result = Array(item.length) as ReturnValue[];
+  await Promise.all([...Array(threads)].map(async () => {
+    while (i < item.length) result[i] = await fn(item[i], i++, item)
+  }));
+  return result;
+};


### PR DESCRIPTION
Previously, there was no limit on the number of images that could be uploaded simultaneously to the specified `images_upload_url`, allowing for an unlimited number of concurrent uploads. Therefore, a new option, `images_upload_max_concurrent_uploads`, was added to control the number of concurrent uploads, with a default limit set to 5.