### PR TITLE
Removing format if we are changing block format to a heading type

### DIFF
--- a/modules/tinymce/src/themes/silver/main/ts/ui/core/ControlUtils.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/core/ControlUtils.ts
@@ -63,6 +63,9 @@ const onSetupEvent = <T>(editor: Editor, event: string, f: (api: T) => void) => 
 const onActionToggleFormat = (editor: Editor) => (rawItem: FormatterFormatItem) => (): void => {
   editor.undoManager.transact(() => {
     editor.focus();
+    if (['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(rawItem.format)) {
+      editor.execCommand('RemoveFormat');
+  }
     editor.execCommand('mceToggleFormat', false, rawItem.format);
   });
 };


### PR DESCRIPTION
### Background
Presently, if a format is applied to a block paragraph, e.g. font size is changed, if we then select a different heading type, the font size remains unchanged. Instead, we would like to override the previous format with the default format of that given heading type.

### Implementation
The type of the format change needs to be checked in order to ensure that it is indeed a heading-type change, since the same function is triggered when the inline style, e.g. Italic or Bold, is changed using the _Format Paragraph_ dropdown menu (in this case we would like to keep the font size unchanged)