### PR TITLE
9443 remove empty option for border styles

### DIFF
--- a/modules/tinymce/src/plugins/table/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/table/demo/ts/demo/Demo.ts
@@ -37,6 +37,12 @@ tinymce.init({
   //   html: '<iframe src="' + data.url + '" width="560" height="314" allowfullscreen="allowfullscreen"></iframe>'});
   // },
   height: 600,
+  table_border_styles:[
+    { title: 'Solid', value: 'solid' },
+    { title: 'Dotted', value: 'dotted' },
+    { title: 'Dashed', value: 'dashed' }
+    // None option is automatically added if no default border style is defined and is missing from defined options
+  ],
   content_style: 'td[data-mce-selected], th[data-mce-selected] { background-color: #2276d2 !important; }' + '.cat { border-color: green; color: red; background-color: }'
 });
 

--- a/modules/tinymce/src/plugins/table/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Options.ts
@@ -18,7 +18,7 @@ const defaultCellBorderWidths = Arr.range(5, (i) => {
   return { title: size, value: size };
 });
 
-const defaultCellBorderStyles = Arr.map([ 'Solid', 'Dotted', 'Dashed', 'Double', 'Groove', 'Ridge', 'Inset', 'Outset', 'None', 'Hidden' ], (type) => {
+const defaultCellBorderStyles = Arr.map(['None', 'Solid', 'Dotted', 'Dashed', 'Double', 'Groove', 'Ridge', 'Inset', 'Outset', 'Hidden' ], (type) => {
   return { title: type, value: type.toLowerCase() };
 });
 

--- a/modules/tinymce/src/plugins/table/main/ts/ui/DialogAdvancedTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/DialogAdvancedTab.ts
@@ -40,7 +40,10 @@ const getBorderWidthTooltip = (dialogName: DialogName): string | undefined => {
 };
 
 const getAdvancedTab = (editor: Editor, dialogName: DialogName): Dialog.TabSpec => {
-  const emptyBorderStyle: Dialog.ListBoxItemSpec[] = [{ text: 'Select...', value: '' }];
+  const emptyBorderStyle: Dialog.ListBoxItemSpec[] = [{text: 'None', value: 'none'}];
+
+  const isDefinedDefaultBorderStyle = Options.getDefaultStyles(editor)["border-style"];
+  const optionsContainNone = Options.getTableBorderStyles(editor).some((item) => item.value === 'none');
 
   const advTabItems: Dialog.BodyComponentSpec[] = [
     {
@@ -48,7 +51,9 @@ const getAdvancedTab = (editor: Editor, dialogName: DialogName): Dialog.TabSpec 
       type: 'listbox',
       label: 'Border style',
       tooltip: getBorderStyleTooltip(dialogName),
-      items: emptyBorderStyle.concat(buildListItems(Options.getTableBorderStyles(editor)))
+      // in case user forgets to define an option for a table without border style and doesn't set default border style,
+      // we need to add it as none option
+      items: (!isDefinedDefaultBorderStyle && !optionsContainNone ? emptyBorderStyle : []).concat(buildListItems(Options.getTableBorderStyles(editor)))
     },
     {
       name: 'bordercolor',
@@ -71,7 +76,7 @@ const getAdvancedTab = (editor: Editor, dialogName: DialogName): Dialog.TabSpec 
     tooltip: getBorderWidthTooltip(dialogName)
   };
 
-  const items = dialogName === 'cell' ? ([ borderWidth ] as Dialog.BodyComponentSpec[]).concat(advTabItems) : advTabItems;
+  const items = dialogName === 'cell' ? ([borderWidth] as Dialog.BodyComponentSpec[]).concat(advTabItems) : advTabItems;
 
   return {
     title: 'Advanced',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/DialogAdvancedTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/DialogAdvancedTab.ts
@@ -76,7 +76,7 @@ const getAdvancedTab = (editor: Editor, dialogName: DialogName): Dialog.TabSpec 
     tooltip: getBorderWidthTooltip(dialogName)
   };
 
-  const items = dialogName === 'cell' ? ([borderWidth] as Dialog.BodyComponentSpec[]).concat(advTabItems) : advTabItems;
+  const items = dialogName === 'cell' ? ([ borderWidth ] as Dialog.BodyComponentSpec[]).concat(advTabItems) : advTabItems;
 
   return {
     title: 'Advanced',


### PR DESCRIPTION
Closes [#9443](https://github.com/mild-blue/slp/issues/9443)

The empty option with **Select...** label was added to option list by default but it doesn't make sense to have it there.

Changes:
1.  I removed this empty option.
2. Default options for border style now have **None** as a first item => default option. So when options for border style are not specified, this is the chosen option for tables with no border style.
3. It makes sense to add **None** option only in one case - when options for border styles are specified and the option don't contain **None** option and default border style is not specified. In other words, we add  **None** because IT IS  THE DEFAULT STYLE when the border style is not specified.

I hope it makes sense. :)




