### PR TITLE
remove default styles of tiny for table border

### DIFF
--- a/modules/oxide/src/less/skins/content/default/content.less
+++ b/modules/oxide/src/less/skins/content/default/content.less
@@ -18,27 +18,6 @@ table:not([cellpadding]) td {
   padding: .4rem;
 }
 
-/* Set default table styles if a table has a positive border attribute
-   and no inline css */
-table[border]:not([border="0"]):not([style*="border-width"]) th,
-table[border]:not([border="0"]):not([style*="border-width"]) td {
-  border-width: 1px;
-}
-
-/* Set default table styles if a table has a positive border attribute
-   and no inline css */
-table[border]:not([border="0"]):not([style*="border-style"]) th,
-table[border]:not([border="0"]):not([style*="border-style"]) td {
-  border-style: solid;
-}
-
-/* Set default table styles if a table has a positive border attribute
-   and no inline css */
-table[border]:not([border="0"]):not([style*="border-color"]) th,
-table[border]:not([border="0"]):not([style*="border-color"]) td {
-  border-color: #ccc;
-}
-
 figure {
   display: table;
   margin: 1rem auto;

--- a/modules/tinymce/src/plugins/table/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/table/demo/ts/demo/Demo.ts
@@ -48,6 +48,7 @@ tinymce.init({
     // every new table will have a border of 1px solid black
     "border-color": "black",
     "border-style": "solid",
+    "border-width": "1px",
     width: "100%",
   },
   content_style: 'td[data-mce-selected], th[data-mce-selected] { background-color: #2276d2 !important; }' + '.cat { border-color: green; color: red; background-color: }'

--- a/modules/tinymce/src/plugins/table/demo/ts/demo/Demo.ts
+++ b/modules/tinymce/src/plugins/table/demo/ts/demo/Demo.ts
@@ -43,6 +43,13 @@ tinymce.init({
     { title: 'Dashed', value: 'dashed' }
     // None option is automatically added if no default border style is defined and is missing from defined options
   ],
+
+  table_default_styles: {
+    // every new table will have a border of 1px solid black
+    "border-color": "black",
+    "border-style": "solid",
+    width: "100%",
+  },
   content_style: 'td[data-mce-selected], th[data-mce-selected] { background-color: #2276d2 !important; }' + '.cat { border-color: green; color: red; background-color: }'
 });
 


### PR DESCRIPTION
These styles sometimes were applied even though we had a different style for table. That means only one thing - removal.
Now Tiny won't have any styles for table border in default skin - user agent stylesheet is applied.

Therefore a `table_default_styles` should be set,

Also, I kept the padding style - because I understand that Tiny tables should be nice and usable even without further styling.

Closes https://github.com/mild-blue/slp/issues/10067