### PR TITLE
localized char search

### DIFF
--- a/modules/tinymce/src/plugins/charmap/main/ts/core/Scan.ts
+++ b/modules/tinymce/src/plugins/charmap/main/ts/core/Scan.ts
@@ -1,6 +1,7 @@
 import { Arr, Strings } from '@ephox/katamari';
 
 import { CharMap, Char } from './CharMap';
+import I18n from "tinymce/core/api/util/I18n";
 
 export interface CharItem {
   readonly value: string;
@@ -20,7 +21,7 @@ const scan = (group: CharMap, pattern: string): CharItem[] => {
   const matches: Char[] = [];
   const lowerCasePattern = pattern.toLowerCase();
   Arr.each(group.characters, (g) => {
-    if (charMatches(g[0], g[1], lowerCasePattern)) {
+    if (charMatches(g[0], I18n.translate([g[1]]), lowerCasePattern)) {
       matches.push(g);
     }
   });


### PR DESCRIPTION
It was not possible to find special char by its localized name. Now it is possible.

This how I adjusted charmap demo for testing:

```js
import { TinyMCE } from 'tinymce/core/api/PublicApi';

declare let tinymce: TinyMCE;

tinymce.addI18n('cs', {
  'Charmap': 'Mapa znaků', // Translation for "Character Map"
  'left parenthesis': 'levá závorka',
  'right parenthesis': 'pravá závorka',
  'left square bracket': 'levá hranatá závorka',
  'right square bracket': 'pravá hranatá závorka',
  'left curly bracket': 'levá složená závorka',
  'right curly bracket': 'pravá složená závorka',
  'left angle bracket': 'levá špičatá závorka',
  'right angle bracket': 'pravá špičatá závorka',
  'leftwards arrow': 'šipka doleva',
  'upwards arrow': 'šipka nahoru',
  'rightwards arrow': 'šipka doprava',
  'downwards arrow': 'šipka dolů'
});

tinymce.init({
  selector: 'textarea.tinymce',
  plugins: 'charmap',
  toolbar: 'charmap',
  language: "cs",
  height: 600,
  charmap_append: [[ 'A'.charCodeAt(0), 'A' ], [ 'B'.charCodeAt(0), 'B' ], [ 'C'.charCodeAt(0), 'C' ], [ 0x1d160, 'note' ]]
});

export {};

```
