### PR TITLE
Dont show any quick toolbar for page break

### DIFF
--- a/modules/tinymce/src/plugins/quickbars/main/ts/selection/Toolbars.ts
+++ b/modules/tinymce/src/plugins/quickbars/main/ts/selection/Toolbars.ts
@@ -1,4 +1,4 @@
-import { Class, SugarElement } from '@ephox/sugar';
+import {Class, SugarElement} from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 
@@ -7,17 +7,17 @@ import * as Options from '../api/Options';
 const addToEditor = (editor: Editor): void => {
   const isEditable = (node: Element | null): boolean => editor.dom.isEditable(node);
   const isInEditableContext = (el: Element) => isEditable(el.parentElement);
+  const isPagebreak = (node: Element) => Class.has(SugarElement.fromDom(node), 'mce-pagebreak');
   const isImage = (node: Element): boolean => {
     const isImageFigure = node.nodeName === 'FIGURE' && /image/i.test(node.className);
     const isImage = node.nodeName === 'IMG' || isImageFigure;
-    const isPagebreak = Class.has(SugarElement.fromDom(node), 'mce-pagebreak');
-    return isImage && isInEditableContext(node) && !isPagebreak;
+    return isImage && isInEditableContext(node);
   };
 
   const imageToolbarItems = Options.getImageToolbarItems(editor);
   if (imageToolbarItems.length > 0) {
     editor.ui.registry.addContextToolbar('imageselection', {
-      predicate: isImage,
+      predicate: (node) => isImage(node) && !isPagebreak(node),
       items: imageToolbarItems,
       position: 'node'
     });
@@ -26,7 +26,7 @@ const addToEditor = (editor: Editor): void => {
   const textToolbarItems = Options.getTextSelectionToolbarItems(editor);
   if (textToolbarItems.length > 0) {
     editor.ui.registry.addContextToolbar('textselection', {
-      predicate: (node) => !isImage(node) && !editor.selection.isCollapsed() && isEditable(node),
+      predicate: (node) => !isImage(node) && !editor.selection.isCollapsed() && isEditable(node) && !isPagebreak(node),
       items: textToolbarItems,
       position: 'selection',
       scope: 'editor'

--- a/modules/tinymce/src/plugins/quickbars/main/ts/selection/Toolbars.ts
+++ b/modules/tinymce/src/plugins/quickbars/main/ts/selection/Toolbars.ts
@@ -11,13 +11,13 @@ const addToEditor = (editor: Editor): void => {
   const isImage = (node: Element): boolean => {
     const isImageFigure = node.nodeName === 'FIGURE' && /image/i.test(node.className);
     const isImage = node.nodeName === 'IMG' || isImageFigure;
-    return isImage && isInEditableContext(node);
+    return isImage && isInEditableContext(node) && !isPagebreak(node);
   };
 
   const imageToolbarItems = Options.getImageToolbarItems(editor);
   if (imageToolbarItems.length > 0) {
     editor.ui.registry.addContextToolbar('imageselection', {
-      predicate: (node) => isImage(node) && !isPagebreak(node),
+      predicate: (node) => isImage(node),
       items: imageToolbarItems,
       position: 'node'
     });
@@ -26,7 +26,7 @@ const addToEditor = (editor: Editor): void => {
   const textToolbarItems = Options.getTextSelectionToolbarItems(editor);
   if (textToolbarItems.length > 0) {
     editor.ui.registry.addContextToolbar('textselection', {
-      predicate: (node) => !isImage(node) && !editor.selection.isCollapsed() && isEditable(node) && !isPagebreak(node),
+      predicate: (node) => !isImage(node) && !isPagebreak(node) && !editor.selection.isCollapsed() && isEditable(node) && !isPagebreak(node),
       items: textToolbarItems,
       position: 'selection',
       scope: 'editor'


### PR DESCRIPTION
If I use plugins `pagebreak` and `quickbars` together pagebreaks become impossible to delete sometimes.

Eg. situation: https://jam.dev/c/0f51bb8a-7896-4309-a803-0e8415ef2ba5
1. Write a last word to the editor
2. Insert pagebreak right after the last word
3. Insert newline + a random text
4. Insert newline + a random text
5. Move cursor to right after the pagebreak
6. Pagebreak cannot be deleted.

This error was caused by showing quick toolbar for text even when only pagebreak is selected. Selecting pagebreak makes cursor move before the pagebreak -> accidental deleting continues there. I believe this is a wrong behavoiur. Therefore I disabled showing quickbars for pagebreaks -> makes them deletable.

Closes https://github.com/mild-blue/slp/issues/10928

