### PR TITLE
Inserting empty paragraph in case editable div inside a non-editable …

### DIFF
--- a/modules/tinymce/src/core/main/ts/delete/BlockRangeDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/BlockRangeDelete.ts
@@ -59,7 +59,7 @@ const emptyEditor = (editor: Editor): Optional<() => void> => {
 
 const getClosestEditableDiv = (editor: Editor): HTMLElement | null => {
   const node = editor.selection.getNode();
-  return node.closest('.editable');
+  return node.closest(`.${editor.getParam('editable_class')}`);
 };
 
 const emptyEditableDiv = (editor: Editor, editableDiv: Element): Optional<() => void> => {

--- a/modules/tinymce/src/core/main/ts/delete/BlockRangeDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/BlockRangeDelete.ts
@@ -20,7 +20,6 @@ const deleteRangeMergeBlocks = (rootNode: SugarElement<Node>, selection: EditorS
       if (!Compare.eq(block1, block2)) {
         return Optional.some(() => {
           rng.deleteContents();
-
           MergeBlocks.mergeBlocks(rootNode, true, block1, block2, schema).each((pos) => {
             selection.setRng(pos.toRange());
           });
@@ -52,14 +51,25 @@ const emptyEditor = (editor: Editor): Optional<() => void> => {
     if (editor.hasEditableRoot()) {
       editor.setContent('');
     } else {
-      editor.setContent(`<div class=${editor.getParam('editable_class')}>${editor.getParam('placeholder')}</div>`);
+      const editableDiv = editor.getBody().querySelector('.editable')
+      if(editableDiv){
+        editableDiv.innerHTML = '<p><br data-mce-bogus="1"></p>';
+      } else {
+        editor.setContent(`<div class=${editor.getParam('editable_class')}>${editor.getParam('placeholder')}</div>`);
+      }
     }
     editor.selection.setCursorLocation();
   });
 };
 
 const deleteRange = (editor: Editor): Optional<() => void> => {
-  const rootNode = SugarElement.fromDom(editor.getBody());
+  let rootNode;
+  const editableDiv = editor.getBody().querySelector('.editable')
+  if(!editor.hasEditableRoot() && editableDiv){
+      rootNode = SugarElement.fromDom(editableDiv as Node);
+  } else {
+    rootNode = SugarElement.fromDom(editor.getBody());
+  }
   const rng = editor.selection.getRng();
   return isEverythingSelected(rootNode, rng) ? emptyEditor(editor) : deleteRangeMergeBlocks(rootNode, editor.selection, editor.schema);
 };

--- a/modules/tinymce/src/core/main/ts/delete/BlockRangeDelete.ts
+++ b/modules/tinymce/src/core/main/ts/delete/BlockRangeDelete.ts
@@ -51,31 +51,50 @@ const emptyEditor = (editor: Editor): Optional<() => void> => {
     if (editor.hasEditableRoot()) {
       editor.setContent('');
     } else {
-      const editableDiv = editor.getBody().querySelector('.editable')
-      if(editableDiv){
-        editableDiv.innerHTML = '<p><br data-mce-bogus="1"></p>';
-      } else {
-        editor.setContent(`<div class=${editor.getParam('editable_class')}>${editor.getParam('placeholder')}</div>`);
-      }
+      editor.setContent(`<div class=${editor.getParam('editable_class')}>${editor.getParam('placeholder')}</div>`);
     }
+    editor.selection.setCursorLocation();
+  });
+};
+
+const getClosestEditableDiv = (editor: Editor): HTMLElement | null => {
+  const node = editor.selection.getNode();
+  return node.closest('.editable');
+};
+
+const emptyEditableDiv = (editor: Editor, editableDiv: Element): Optional<() => void> => {
+  return Optional.some(() => {
+    editableDiv.innerHTML = '<p><br data-mce-bogus="1"></p>';
     editor.selection.setCursorLocation();
   });
 };
 
 const deleteRange = (editor: Editor): Optional<() => void> => {
   let rootNode;
-  const editableDiv = editor.getBody().querySelector('.editable')
+  const editableDiv = getClosestEditableDiv(editor);
+  const rng = editor.selection.getRng();
   if(!editor.hasEditableRoot() && editableDiv){
       rootNode = SugarElement.fromDom(editableDiv as Node);
-  } else {
-    rootNode = SugarElement.fromDom(editor.getBody());
-  }
-  const rng = editor.selection.getRng();
+      return isEverythingSelected(rootNode, rng) ? emptyEditableDiv(editor, editableDiv) : deleteRangeMergeBlocks(rootNode, editor.selection, editor.schema);
+  } 
+  rootNode = SugarElement.fromDom(editor.getBody());
   return isEverythingSelected(rootNode, rng) ? emptyEditor(editor) : deleteRangeMergeBlocks(rootNode, editor.selection, editor.schema);
 };
 
+
+const deleteSymbol = (editor: Editor): Optional<() => void> => {
+  if(editor.hasEditableRoot()){
+    return Optional.none();
+  }
+  const editableDiv = getClosestEditableDiv(editor);
+  if(editableDiv?.textContent?.length == 1){
+    return emptyEditableDiv(editor, editableDiv);
+  }
+  return Optional.none();
+}
+
 const backspaceDelete = (editor: Editor, _forward: boolean): Optional<() => void> =>
-  editor.selection.isCollapsed() ? Optional.none() : deleteRange(editor);
+  editor.selection.isCollapsed() ? deleteSymbol(editor) : deleteRange(editor);
 
 export {
   backspaceDelete


### PR DESCRIPTION
…root is emptied

### Background
Previously, emptying contents of a  `<div class="editable">`  was treated as emptying some regular element, i.e. only `<br data-mce-bogus="1">` was inserted without any wrapping elements which created issues down the line. 

### Implementation
For editors with editable roots, or without the  `<div class="editable">` , nothing changes, but for editors wihtout an editable root containing instead an editable div, emptying that div is treated as emptying a the whole editor, and a proper empty paragraph `<p><br data-mce-bogus="1"></p>` is inserted upon emptying the content.


### Testing
E.g. change `/opentiny/modules/tinymce/src/models/dom/demo/html/demo/basic-demo.html` to
```
...
<div style="height:600px;" class="tinymce">
  <h1>Heading 1</h1>
  <div class="editable">
    <p>prvni paragraf</p>
    <p>druhy paragraf</p>
  </div>
</div>
...
```
and add the following to `/opentiny/modules/tinymce/src/models/dom/demo/ts/demo/Demo.ts` :
```
  editable_root: false,
  editable_class: "editable",
```

then proceed to empty the editable content and observe that an empty paragraph is inserted
