### PR TITLE
Preventing deletion of the editable class

### DIFF
--- a/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
+++ b/modules/tinymce/src/core/main/ts/fmt/RemoveFormat.ts
@@ -286,8 +286,9 @@ const removeNodeFormatInternal = (ed: Editor, format: Format, vars?: FormatVars,
           if (currentValue) {
             // Build new class value where everything is removed except the internal prefixed classes
             let valueOut = '';
+            const editableClass = ed.getParam('editable_class');
             Arr.each(currentValue.split(/\s+/), (cls) => {
-              if (/mce\-\w+/.test(cls)) {
+              if (/mce-\w+/.test(cls) || (editableClass && cls === editableClass)) {
                 valueOut += (valueOut ? ' ' : '') + cls;
               }
             });


### PR DESCRIPTION
### Background
Když se pomocí Ctrl+A označil celej content editablu divu a pak se změnil styl (např z paragrafu na heading) tak to overwritelo `class="editable"`, což u nás v editoru pak způsobovalo, že se přidávali nový editable divs, který pak nesprávně wrapovali i názvy dokumentů respektive v drobné změně pak nešlo nic editovat

### Implementation
Kotrolujeme zda class je editable pří odstraňování formátu.

### Testing
_basic-demo.html_
```
<div style="height:600px;" class="tinymce">
  <h1>Heading 1</h1>
  <div class="editable">
    <p>prvni paragraf</p>
    <p>druhy paragraf</p>
  </div>
</div>
```

Demo.ts:
```
tinymce.init({
  selector: 'div.tinymce',
  editable_root: false,
  editable_class: "editable",
  setup: (ed) => {
    ed.on('init', () => {
      const runtimeModel = ed.model;
      // eslint-disable-next-line no-console
      console.log('demo model created', runtimeModel);
    });
  }
});
```