### PR TITLE
Improve table resizing when deleting rows and columns

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,8 @@ indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 end_of_line = lf
+
+# Idea overrides
+ij_typescript_use_double_quotes = false
+ij_typescript_imports_wrap = off
+ij_typescript_spaces_within_object_literal_braces = true

--- a/modules/snooker/src/main/ts/ephox/snooker/api/Structs.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/api/Structs.ts
@@ -2,6 +2,7 @@ import { Arr } from '@ephox/katamari';
 import { SugarElement } from '@ephox/sugar';
 
 import { CellElement, RowElement, RowCell } from '../util/TableTypes';
+import { ClientRect } from "opentiny/lib/core/main/ts/geom/ClientRect";
 
 export interface Dimension {
   readonly width: number;
@@ -30,6 +31,7 @@ export interface Coords {
 
 export interface Detail<T extends CellElement = CellElement> {
   readonly element: SugarElement<T>;
+  readonly elementRect?: ClientRect;
   readonly rowspan: number;
   readonly colspan: number;
 }

--- a/modules/snooker/src/main/ts/ephox/snooker/model/RunOperation.ts
+++ b/modules/snooker/src/main/ts/ephox/snooker/model/RunOperation.ts
@@ -89,7 +89,12 @@ const extractCells = (warehouse: Warehouse, target: TargetSelection, predicate: 
       .bind((lc) => findInWarehouse(warehouse, lc))
       .filter(predicate);
   });
-  const cells = Optionals.cat(details);
+
+  // Preserve the size of targeted cells
+  const cells = Optionals.cat(details).map((detail) => ({
+    ...detail,
+    elementRect: detail.element.dom.getBoundingClientRect()
+  }));
   return Optionals.someIf(cells.length > 0, cells);
 };
 


### PR DESCRIPTION
Problém byl v tom, že jak se mazal řádek z DOMu tabulky, tak se ztrácela informace o jeho rozměrech. Přidala jsem proto novou nepovinnou property `elementRect`, do které uložím rozměry odmazaváných řádků (viz funkce `extractCells`). Pak tyto uložené rozměry následně použiji v adjustment funkci, která se volá v rámci `eraseRows`, a zmenším výšku tabulky o výšky odmazaných řádků.