### PR TITLE
remove styles for empty table border

### DIFF
--- a/modules/oxide/src/less/theme/content/table/table.less
+++ b/modules/oxide/src/less/theme/content/table/table.less
@@ -2,7 +2,7 @@
 // Tables
 //
 
-@empty-table-border: 1px dashed #bbb;
+@empty-table-border: none;
 
 // Show a dashed border inside TinyMCE if the table
 // lacks any border attributes or styles or have them


### PR DESCRIPTION
We want to unify the display of borderless tables to ensure the grey dashed line never appears. I’ve therefore set border: none on these tables.