### PR TITLE
Do not insert bogus to a new list item

### DIFF
--- a/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
+++ b/modules/tinymce/src/core/main/ts/newline/NewLineUtils.ts
@@ -124,8 +124,8 @@ const isListItemParentBlock = (editor: Editor): boolean => {
   }).isSome();
 };
 
-const emptyBlock = (elm: Element): void => {
-  elm.innerHTML = '<br data-mce-bogus="1">';
+const emptyBlock = (elm: Element, addBogus: boolean = true): void => {
+  elm.innerHTML = addBogus ? '<br data-mce-bogus="1">' : '<br>';
 };
 
 const applyAttributes = (editor: Editor, node: Element, forcedRootBlockAttrs: Record<string, string>) => {
@@ -219,7 +219,8 @@ const createNewBlock = (
 
   setForcedBlockAttrs(editor, block);
 
-  emptyBlock(caretNode);
+  const addBogus = parentBlockName !== 'LI'; // do not add bogus to list item content
+  emptyBlock(caretNode, addBogus);
 
   return block;
 };


### PR DESCRIPTION
When editing a list like the following:

```html
<ol>
  <li>item 1</li>
  <li>item 2</li>
</ol>
```

which renders as:

```
  1. item 1
  2. item 2
```

a user might press `Enter` and then `Backspace` at the end of "item 1" to insert a visual newline between the items, resulting in:
```
  1. item 1
  
  2. item 2
```

In Tiny, this creates an empty line between the two list items defined as `<br data-mce-bogus="1">`. This bogus `<br>` is used as a placeholder to ensure the element is selectable and visually rendered, even when empty.

However, when calling `editor.getContent()`, Tiny strips out `br` elements marked with `data-mce-bogus="1"` to avoid polluting the output with placeholders. As a result, the visual newline created by the user is lost in the serialized content.

This PR addresses that by inserting a plain `<br>` instead of a bogus one when the user creates a new list item via `Enter`. This preserves the empty line visually and ensures it's retained in the output HTML from `getContent()`.