### PR TITLE
Curdopet/add options to select table menu items

### DIFF
--- a/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
@@ -126,6 +126,7 @@ export default (): void => {
     'bullist numlist outdent indent | link image | print preview media | forecolor backcolor emoticons table codesample code language | ltr rtl',
     contextmenu: 'link linkchecker image table lists configurepermanentpen',
     table_contextmenu: [ 'cell', 'row', 'column', 'tableprops', 'deletetable' ],
+    table_contextmenu_flatten: true,
     table_cell_contextmenu: [ 'tablecellprops', 'tablemergecells' ],
     table_row_contextmenu: [ 'tableinsertrowbefore', 'tabledeleterow', 'tablerowprops' ],
     table_column_contextmenu: [ 'tableinsertcolumnbefore', 'tabledeletecolumn' ],

--- a/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
@@ -125,11 +125,10 @@ export default (): void => {
     toolbar: 'undo redo sidebar1 fontsizeinput | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | align lineheight fontsize fontfamily blocks styles insertfile | styles | ' +
     'bullist numlist outdent indent | link image | print preview media | forecolor backcolor emoticons table codesample code language | ltr rtl',
     contextmenu: 'link linkchecker image table lists configurepermanentpen',
-    table_contextmenu: [ 'cell', 'row', 'column', 'tableprops', 'deletetable' ],
+    table_contextmenu: [ 'cell', 'row', 'tableprops', 'deletetable' ],
     table_contextmenu_flatten: true,
-    table_cell_contextmenu: [ 'tablecellprops', 'tablemergecells' ],
-    table_row_contextmenu: [ 'tableinsertrowbefore', 'tabledeleterow', 'tablerowprops' ],
-    table_column_contextmenu: [ 'tableinsertcolumnbefore', 'tabledeletecolumn' ],
+    table_cell_contextmenu: [ 'tablecellprops', 'tablemergecells', 'tablesplitcells' ],
+    table_row_contextmenu: [ 'tablerowprops' ],
 
     // Multiple toolbar array
     // toolbar: ['undo redo sidebar1 align fontsize insertfile | fontfamily blocks styles insertfile | styles | bold italic',

--- a/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
@@ -125,6 +125,10 @@ export default (): void => {
     toolbar: 'undo redo sidebar1 fontsizeinput | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | align lineheight fontsize fontfamily blocks styles insertfile | styles | ' +
     'bullist numlist outdent indent | link image | print preview media | forecolor backcolor emoticons table codesample code language | ltr rtl',
     contextmenu: 'link linkchecker image table lists configurepermanentpen',
+    table_contextmenu: [ 'cell', 'row', 'column', 'tableprops', 'deletetable' ],
+    table_cell_contextmenu: [ 'tablecellprops', 'tablemergecells' ],
+    table_row_contextmenu: [ 'tableinsertrowbefore', 'tabledeleterow', 'tablerowprops' ],
+    table_column_contextmenu: [ 'tableinsertcolumnbefore', 'tabledeletecolumn' ],
 
     // Multiple toolbar array
     // toolbar: ['undo redo sidebar1 align fontsize insertfile | fontfamily blocks styles insertfile | styles | bold italic',

--- a/modules/tinymce/src/plugins/table/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Options.ts
@@ -9,9 +9,9 @@ import { UserListItem, UserListValue } from '../ui/UiUtils';
 
 const defaultTableToolbar = 'tableprops tabledelete | tableinsertrowbefore tableinsertrowafter tabledeleterow | tableinsertcolbefore tableinsertcolafter tabledeletecol';
 
-const defaultTableCellInputs = 'width height celltype scope halign valign class';
-const defaultTableRowInputs = 'type align class';
-const defaultTableInputs = 'width height cellspacing cellpadding border caption align class';
+const defaultTableCellInputs = 'width height celltype scope halign valign backgroundcolor class';
+const defaultTableRowInputs = 'type align backgroundcolor class';
+const defaultTableInputs = 'width height cellspacing cellpadding border backgroundcolor caption align class';
 
 const defaultCellBorderWidths = Arr.range(5, (i) => {
   const size = `${i + 1}px`;

--- a/modules/tinymce/src/plugins/table/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Options.ts
@@ -9,8 +9,8 @@ import { UserListItem, UserListValue } from '../ui/UiUtils';
 
 const defaultTableToolbar = 'tableprops tabledelete | tableinsertrowbefore tableinsertrowafter tabledeleterow | tableinsertcolbefore tableinsertcolafter tabledeletecol';
 
-const defaultTableCellInputs = 'width celltype scope halign valign class';
-const defaultTableRowInputs = 'type align height class';
+const defaultTableCellInputs = 'width height celltype scope halign valign class';
+const defaultTableRowInputs = 'type align class';
 const defaultTableInputs = 'width height cellspacing cellpadding border caption align class';
 
 const defaultCellBorderWidths = Arr.range(5, (i) => {

--- a/modules/tinymce/src/plugins/table/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Options.ts
@@ -134,6 +134,11 @@ const register = (editor: Editor): void => {
     default: []
   });
 
+  registerOption('table_contextmenu_flatten', {
+    processor: 'boolean',
+    default: false
+  });
+
   registerOption('table_row_contextmenu', {
     processor: 'string[]',
     default: []
@@ -176,6 +181,7 @@ const getRowClassList = option<UserListItem[]>('table_row_class_list');
 const getTableClassList = option<UserListItem[]>('table_class_list');
 const getToolbar = option<string>('table_toolbar');
 const getTableContextMenu = option<string[]>('table_contextmenu');
+const getTableContextMenuFlatten = option<boolean>('table_contextmenu_flatten');
 const getTableRowContextMenu = option<string[]>('table_row_contextmenu');
 const getTableColumnContextMenu = option<string[]>('table_column_contextmenu');
 const getTableCellContextMenu = option<string[]>('table_cell_contextmenu');
@@ -205,6 +211,9 @@ const getDefaultAttributes = (editor: Editor): Record<string, string> => {
 const isTableContextMenuSet = (editor: Editor): boolean =>
   editor.options.isSet('table_contextmenu');
 
+const isTableContextMenuFlatten = (editor: Editor): boolean =>
+  getTableContextMenuFlatten(editor);
+
 const isTableRowContextMenuSet = (editor: Editor): boolean =>
   editor.options.isSet('table_row_contextmenu');
 
@@ -231,6 +240,7 @@ export {
   getTableClassList,
   getToolbar,
   getTableContextMenu,
+  getTableContextMenuFlatten,
   getTableRowContextMenu,
   getTableColumnContextMenu,
   getTableCellContextMenu,
@@ -239,6 +249,7 @@ export {
   getTableBackgroundColorMap,
   getTableBorderColorMap,
   isTableContextMenuSet,
+  isTableContextMenuFlatten,
   isTableRowContextMenuSet,
   isTableColumnContextMenuSet,
   isTableCellContextMenuSet

--- a/modules/tinymce/src/plugins/table/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Options.ts
@@ -129,6 +129,26 @@ const register = (editor: Editor): void => {
     default: defaultTableToolbar
   });
 
+  registerOption('table_contextmenu', {
+    processor: 'string[]',
+    default: []
+  });
+
+  registerOption('table_row_contextmenu', {
+    processor: 'string[]',
+    default: []
+  });
+
+  registerOption('table_column_contextmenu', {
+    processor: 'string[]',
+    default: []
+  });
+
+  registerOption('table_cell_contextmenu', {
+    processor: 'string[]',
+    default: []
+  });
+
   registerOption('table_background_color_map', {
     processor: 'object[]',
     default: []
@@ -155,6 +175,10 @@ const getCellClassList = option<UserListItem[]>('table_cell_class_list');
 const getRowClassList = option<UserListItem[]>('table_row_class_list');
 const getTableClassList = option<UserListItem[]>('table_class_list');
 const getToolbar = option<string>('table_toolbar');
+const getTableContextMenu = option<string[]>('table_contextmenu');
+const getTableRowContextMenu = option<string[]>('table_row_contextmenu');
+const getTableColumnContextMenu = option<string[]>('table_column_contextmenu');
+const getTableCellContextMenu = option<string[]>('table_cell_contextmenu');
 const getTableBackgroundColorMap = option<UserListValue[]>('table_background_color_map');
 const getTableBorderColorMap = option<UserListValue[]>('table_border_color_map');
 
@@ -178,6 +202,18 @@ const getDefaultAttributes = (editor: Editor): Record<string, string> => {
   return options.isSet('table_default_attributes') ? defaultAttributes : determineDefaultAttributes(editor, defaultAttributes);
 };
 
+const isTableContextMenuSet = (editor: Editor): boolean =>
+  editor.options.isSet('table_contextmenu');
+
+const isTableRowContextMenuSet = (editor: Editor): boolean =>
+  editor.options.isSet('table_row_contextmenu');
+
+const isTableColumnContextMenuSet = (editor: Editor): boolean =>
+  editor.options.isSet('table_column_contextmenu');
+
+const isTableCellContextMenuSet = (editor: Editor): boolean =>
+  editor.options.isSet('table_cell_contextmenu');
+
 export {
   register,
   getDefaultAttributes,
@@ -194,8 +230,16 @@ export {
   getRowClassList,
   getTableClassList,
   getToolbar,
+  getTableContextMenu,
+  getTableRowContextMenu,
+  getTableColumnContextMenu,
+  getTableCellContextMenu,
   getTableBorderWidths,
   getTableBorderStyles,
   getTableBackgroundColorMap,
-  getTableBorderColorMap
+  getTableBorderColorMap,
+  isTableContextMenuSet,
+  isTableRowContextMenuSet,
+  isTableColumnContextMenuSet,
+  isTableCellContextMenuSet
 };

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
@@ -68,6 +68,7 @@ const updateAdvancedProps = (modifier: DomModifier, data: Required<CellData>, sh
 
 const applyStyleData = (editor: Editor, cells: SelectedCell[], data: CellData, wasChanged: (key: string) => boolean): void => {
   const isSingleCell = cells.length === 1;
+  const rowsSeen = new Set<HTMLTableRowElement>();
   Arr.each(cells, (item) => {
     const cellElm = item.element;
     const shouldOverrideCurrentValue = isSingleCell ? Fun.always : wasChanged;
@@ -78,6 +79,17 @@ const applyStyleData = (editor: Editor, cells: SelectedCell[], data: CellData, w
 
     if (Options.hasAdvancedCellTab(editor)) {
       updateAdvancedProps(modifier, data as Required<CellData>, shouldOverrideCurrentValue);
+    }
+
+    if (shouldOverrideCurrentValue('height')) {
+      const rowElm = cellElm.parentElement as HTMLTableRowElement | null;
+      if (rowElm !== null && !rowsSeen.has(rowElm)) {
+        rowsSeen.add(rowElm);
+        editor.dom.setStyle(rowElm, 'height', Utils.addPxSuffix(data.height));
+        if (wasChanged('height')) {
+          Array.from(rowElm.cells).forEach((cell) => editor.dom.setStyle(cell, 'height', null));
+        }
+      }
     }
 
     // Apply alignment

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
@@ -27,7 +27,7 @@ const children: Dialog.BodyComponentSpec[] = [
     name: 'height',
     type: 'input',
     label: 'Height',
-    tooltip: 'Row height in pixels (e.g., 20px).'
+    tooltip: 'Row height in pixels (e.g., 20px). If the height change does not apply to the row, remove the table height in Table Properties and try again.'
   },
   {
     name: 'backgroundcolor',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
@@ -30,6 +30,12 @@ const children: Dialog.BodyComponentSpec[] = [
     tooltip: 'Row height in pixels (e.g., 20px).'
   },
   {
+    name: 'backgroundcolor',
+    type: 'colorinput',
+    label: 'Background color',
+    tooltip: 'Background color of the cell.'
+  },
+  {
     name: 'celltype',
     type: 'listbox',
     label: 'Cell type',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
@@ -24,6 +24,12 @@ const children: Dialog.BodyComponentSpec[] = [
     tooltip: 'Cell width in pixels or percentage (e.g., 50px or 10%).'
   },
   {
+    name: 'height',
+    type: 'input',
+    label: 'Height',
+    tooltip: 'Row height in pixels (e.g., 20px).'
+  },
+  {
     name: 'celltype',
     type: 'listbox',
     label: 'Cell type',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/DialogAdvancedTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/DialogAdvancedTab.ts
@@ -18,17 +18,6 @@ const getBorderColorTooltip = (dialogName: DialogName): string => {
   }
 };
 
-const getBackgroundColourTooltip = (dialogName: DialogName): string => {
-  switch (dialogName) {
-    case 'table':
-      return 'Changes the background color of all cells in the table, except for those set individually through Cell Properties or Row Properties.';
-    case 'row':
-      return 'Changes the background color of all cells in the row, except for those set individually through Cell Properties.';
-    case 'cell':
-      return `Background color of the cell.`;
-  }
-};
-
 const getBorderWidthTooltip = (dialogName: DialogName): string | undefined => {
   switch (dialogName) {
     case 'table':
@@ -60,12 +49,6 @@ const getAdvancedTab = (editor: Editor, dialogName: DialogName): Dialog.TabSpec 
       type: 'colorinput',
       label: 'Border color',
       tooltip: getBorderColorTooltip(dialogName)
-    },
-    {
-      name: 'backgroundcolor',
-      type: 'colorinput',
-      label: 'Background color',
-      tooltip: getBackgroundColourTooltip(dialogName)
     }
   ];
 
@@ -79,7 +62,7 @@ const getAdvancedTab = (editor: Editor, dialogName: DialogName): Dialog.TabSpec 
   const items = dialogName === 'cell' ? ([ borderWidth ] as Dialog.BodyComponentSpec[]).concat(advTabItems) : advTabItems;
 
   return {
-    title: 'Advanced',
+    title: 'Border',
     name: 'advanced',
     items
   };

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
@@ -42,7 +42,6 @@ export type TableData = {
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type RowData = {
-  readonly height: string;
   readonly class: string;
   readonly align: string;
   readonly type: string;
@@ -54,6 +53,7 @@ export type RowData = {
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type CellData = {
   readonly width: string;
+  readonly height: string;
   readonly scope: string;
   readonly celltype: 'td' | 'th';
   readonly class: string;
@@ -207,7 +207,6 @@ const extractDataFromTableElement = (editor: Editor, elm: Element, hasAdvTableTa
 const extractDataFromRowElement = (editor: Editor, elm: HTMLTableRowElement, hasAdvancedRowTab: boolean): RowData => {
   const dom = editor.dom;
   return {
-    height: dom.getStyle(elm, 'height') || dom.getAttrib(elm, 'height'),
     class: dom.getAttrib(elm, 'class', ''),
     type: getRowType(elm),
     align: getHAlignment(editor, elm),
@@ -218,11 +217,13 @@ const extractDataFromRowElement = (editor: Editor, elm: HTMLTableRowElement, has
 const extractDataFromCellElement = (editor: Editor, cell: HTMLTableCellElement, hasAdvancedCellTab: boolean, column: Optional<HTMLTableColElement>): CellData => {
   const dom = editor.dom;
   const colElm = column.getOr(cell);
+  const rowElm = cell.parentElement;
 
   const getStyle = (element: HTMLElement, style: string) => dom.getStyle(element, style) || dom.getAttrib(element, style);
 
   return {
     width: getStyle(colElm, 'width'),
+    height: rowElm ? (dom.getStyle(rowElm, 'height') || dom.getAttrib(rowElm, 'height')) : '',
     scope: dom.getAttrib(cell, 'scope'),
     celltype: Utils.getNodeName(cell) as 'td' | 'th',
     class: dom.getAttrib(cell, 'class', ''),
@@ -250,4 +251,3 @@ export {
   extractDataFromSettings,
   getValidBorderWidth
 };
-

--- a/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
@@ -31,6 +31,21 @@ const onSetupEditable = (editor: Editor) => (api: Menu.MenuItemInstanceApi): Voi
   };
 };
 
+const filterContextMenu = (menu: string, allowed: string[]): string => {
+  if (allowed.length === 0) {
+    return '';
+  }
+
+  const allowedSet = new Set(allowed);
+  const filteredGroups = menu.split('|')
+    .map((group) => group.trim())
+    .map((group) => group.length === 0 ? [] : group.split(/\s+/).filter((item) => allowedSet.has(item)))
+    .filter((items) => items.length > 0)
+    .map((items) => items.join(' '));
+
+  return filteredGroups.join(' | ');
+};
+
 const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets): void => {
   const cmd = (command: string) => () => editor.execCommand(command);
 
@@ -222,27 +237,33 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets): void 
   });
 
   // if any of the row menu items returned true
-  if (Arr.contains(hasRowMenuItems, true)) {
+  const rowMenuItems = 'tableinsertrowbefore tableinsertrowafter tabledeleterow tablerowprops | tablecutrow tablecopyrow tablepasterowbefore tablepasterowafter';
+  const filteredRowMenuItems = Options.isTableRowContextMenuSet(editor) ? filterContextMenu(rowMenuItems, Options.getTableRowContextMenu(editor)) : rowMenuItems;
+  if (Arr.contains(hasRowMenuItems, true) && filteredRowMenuItems.length > 0) {
     editor.ui.registry.addNestedMenuItem('row', {
       type: 'nestedmenuitem',
       text: 'Row',
-      getSubmenuItems: Fun.constant('tableinsertrowbefore tableinsertrowafter tabledeleterow tablerowprops | tablecutrow tablecopyrow tablepasterowbefore tablepasterowafter')
+      getSubmenuItems: Fun.constant(filteredRowMenuItems)
     });
   }
 
-  if (Arr.contains(hasColumnMenuItems, true)) {
+  const columnMenuItems = 'tableinsertcolumnbefore tableinsertcolumnafter tabledeletecolumn | tablecutcolumn tablecopycolumn tablepastecolumnbefore tablepastecolumnafter';
+  const filteredColumnMenuItems = Options.isTableColumnContextMenuSet(editor) ? filterContextMenu(columnMenuItems, Options.getTableColumnContextMenu(editor)) : columnMenuItems;
+  if (Arr.contains(hasColumnMenuItems, true) && filteredColumnMenuItems.length > 0) {
     editor.ui.registry.addNestedMenuItem('column', {
       type: 'nestedmenuitem',
       text: 'Column',
-      getSubmenuItems: Fun.constant('tableinsertcolumnbefore tableinsertcolumnafter tabledeletecolumn | tablecutcolumn tablecopycolumn tablepastecolumnbefore tablepastecolumnafter')
+      getSubmenuItems: Fun.constant(filteredColumnMenuItems)
     });
   }
 
-  if (Arr.contains(hasCellMenuItems, true)) {
+  const cellMenuItems = 'tablecellprops tablemergecells tablesplitcells';
+  const filteredCellMenuItems = Options.isTableCellContextMenuSet(editor) ? filterContextMenu(cellMenuItems, Options.getTableCellContextMenu(editor)) : cellMenuItems;
+  if (Arr.contains(hasCellMenuItems, true) && filteredCellMenuItems.length > 0) {
     editor.ui.registry.addNestedMenuItem('cell', {
       type: 'nestedmenuitem',
       text: 'Cell',
-      getSubmenuItems: Fun.constant('tablecellprops tablemergecells tablesplitcells')
+      getSubmenuItems: Fun.constant(filteredCellMenuItems)
     });
   }
 
@@ -251,7 +272,7 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets): void 
       // context menu fires before node change, so check the selection here first
       selectionTargets.resetTargets();
       // ignoring element since it's monitored elsewhere
-      return selectionTargets.targets().fold(Fun.constant(''), (targets) => {
+      const menu = selectionTargets.targets().fold(Fun.constant(''), (targets) => {
         // If clicking in a caption, then we shouldn't show the cell/row/column options
         if (SugarNode.name(targets.element) === 'caption') {
           return 'tableprops deletetable';
@@ -259,6 +280,7 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets): void 
           return 'cell row column | advtablesort | tableprops deletetable';
         }
       });
+      return Options.isTableContextMenuSet(editor) ? filterContextMenu(menu, Options.getTableContextMenu(editor)) : menu;
     }
   });
 

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialog.ts
@@ -1,6 +1,6 @@
 import { Arr, Fun, Obj } from '@ephox/katamari';
 import { TableLookup } from '@ephox/snooker';
-import { SelectorFilter, SugarElement } from '@ephox/sugar';
+import { SugarElement } from '@ephox/sugar';
 
 import Editor from 'tinymce/core/api/Editor';
 import { Dialog } from 'tinymce/core/api/ui/Ui';
@@ -22,9 +22,6 @@ const updateSimpleProps = (modifier: DomModifier, data: RowData, shouldUpdate: (
   if (shouldUpdate('class') && data.class !== 'mce-no-match') {
     modifier.setAttrib('class', data.class);
   }
-  if (shouldUpdate('height')) {
-    modifier.setStyle('height', Utils.addPxSuffix(data.height));
-  }
 };
 
 const updateAdvancedProps = (modifier: DomModifier, data: Required<RowData>, shouldUpdate: (key: string) => boolean): void => {
@@ -43,20 +40,12 @@ const applyStyleData = (editor: Editor, rows: HTMLTableRowElement[], data: RowDa
   const isSingleRow = rows.length === 1;
   const shouldOverrideCurrentValue = isSingleRow ? Fun.always : wasChanged;
   Arr.each(rows, (rowElm) => {
-    const rowCells = SelectorFilter.children<HTMLTableCellElement>(SugarElement.fromDom(rowElm), 'td,th');
     const modifier = DomModifier.normal(editor, rowElm);
 
     updateSimpleProps(modifier, data, shouldOverrideCurrentValue);
 
     if (Options.hasAdvancedRowTab(editor)) {
       updateAdvancedProps(modifier, data as Required<RowData>, shouldOverrideCurrentValue);
-    }
-
-    // TINY-10617: Simplify number of height styles when applying height on tr
-    if (wasChanged('height')) {
-      Arr.each(rowCells, (cell) => {
-        editor.dom.setStyle(cell.dom, 'height', null);
-      });
     }
 
     if (wasChanged('align')) {
@@ -165,4 +154,3 @@ const open = (editor: Editor): void => {
 };
 
 export { open };
-

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialogGeneralTab.ts
@@ -38,12 +38,6 @@ const formChildren: Dialog.BodyComponentSpec[] = [
       { text: 'Center', value: 'center' },
       { text: 'Right', value: 'right' }
     ]
-  },
-  {
-    label: 'Height',
-    name: 'height',
-    type: 'input',
-    tooltip: 'Row height in pixels (e.g., 20px).'
   }
 ];
 

--- a/modules/tinymce/src/plugins/table/main/ts/ui/RowDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/RowDialogGeneralTab.ts
@@ -38,6 +38,12 @@ const formChildren: Dialog.BodyComponentSpec[] = [
       { text: 'Center', value: 'center' },
       { text: 'Right', value: 'right' }
     ]
+  },
+  {
+    name: 'backgroundcolor',
+    type: 'colorinput',
+    label: 'Background color',
+    tooltip: 'Changes the background color of all cells in the row, except for those set individually through Cell Properties.'
   }
 ];
 

--- a/modules/tinymce/src/plugins/table/main/ts/ui/TableDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/TableDialogGeneralTab.ts
@@ -53,6 +53,12 @@ const getItems = (editor: Editor, classes: Dialog.ListBoxItemSpec[], insertNewTa
       tooltip: 'Width of the border for the entire table and individual cells.'
     },
     {
+      name: 'backgroundcolor',
+      type: 'colorinput',
+      label: 'Background color',
+      tooltip: 'Changes the background color of all cells in the table, except for those set individually through Cell Properties or Row Properties.'
+    },
+    {
       type: 'label',
       label: 'Caption',
       name: 'caption',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
@@ -115,6 +115,66 @@ const filterNoneItem = (list: UserListItem[]): UserListItem[] =>
     }
   });
 
+const filterContextMenu = (menu: string, allowed: string[]): string => {
+  if (allowed.length === 0) {
+    return '';
+  }
+
+  const allowedSet = new Set(allowed);
+  const filteredGroups = menu.split('|')
+    .map((group) => group.trim())
+    .map((group) => group.length === 0 ? [] : group.split(/\s+/).filter((item) => allowedSet.has(item)))
+    .filter((items) => items.length > 0)
+    .map((items) => items.join(' '));
+
+  return filteredGroups.join(' | ');
+};
+
+const flattenContextMenu = (menu: string, replacements: Record<string, string>): string => {
+  const groups = menu.split('|')
+    .map((group) => group.trim())
+    .filter((group) => group.length > 0);
+
+  const flattened: string[] = [];
+  const addGroup = (items: string[]) => {
+    if (items.length > 0) {
+      flattened.push(items.join(' '));
+    }
+  };
+
+  Arr.each(groups, (group) => {
+    const tokens = group.split(/\s+/).filter((token) => token.length > 0);
+    let current: string[] = [];
+
+    Arr.each(tokens, (token) => {
+      const replacement = replacements[token];
+      if (replacement === undefined) {
+        current.push(token);
+      } else if (replacement.length === 0) {
+        return;
+      } else {
+        const replacementGroups = replacement.split('|')
+          .map((repGroup) => repGroup.trim())
+          .filter((repGroup) => repGroup.length > 0);
+
+        if (replacementGroups.length === 1) {
+          current = current.concat(replacementGroups[0].split(/\s+/).filter((item) => item.length > 0));
+        } else {
+          addGroup(current);
+          current = [];
+          Arr.each(replacementGroups, (repGroup) => {
+            addGroup(repGroup.split(/\s+/).filter((item) => item.length > 0));
+          });
+        }
+      }
+    });
+
+    addGroup(current);
+  });
+
+  return flattened.join(' | ');
+};
+
 const generateMenuItemsCallback = (editor: Editor, items: UserListItem[], format: string, onAction: (value: string) => void) =>
   (callback: (items: Menu.NestedMenuItemContents[]) => void): void =>
     callback(buildMenuItems(editor, items, format, onAction));
@@ -159,6 +219,8 @@ export {
   buildColorMenu,
   generateMenuItemsCallback,
   filterNoneItem,
+  filterContextMenu,
+  flattenContextMenu,
   changeRowHeader,
   changeColumnHeader,
   applyTableCellStyle

--- a/modules/tinymce/src/plugins/table/test/ts/browser/HelpersTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/HelpersTest.ts
@@ -30,13 +30,14 @@ describe('browser.tinymce.plugins.table.HelpersTest', () => {
     );
     const td = UiFinder.findIn<HTMLTableCellElement>(TinyDom.body(editor), 'td.foo').getOrDie();
     const cellData = Helpers.extractDataFromCellElement(editor, td.dom, true, Optional.none());
-    assert.hasAllKeys(cellData, [ 'class', 'scope', 'celltype', 'halign', 'valign', 'width', 'backgroundcolor', 'bordercolor', 'borderstyle', 'borderwidth' ]);
+    assert.hasAllKeys(cellData, [ 'class', 'scope', 'celltype', 'halign', 'valign', 'width', 'height', 'backgroundcolor', 'bordercolor', 'borderstyle', 'borderwidth' ]);
     assert.equal(cellData.class, 'foo', 'Extracts class');
     assert.equal(cellData.scope, 'row', 'Extracts scope');
     assert.equal(cellData.celltype, 'td', 'Extracts celltype');
     assert.equal(cellData.halign, 'left', 'Extracts halign');
     assert.equal(cellData.valign, 'middle', 'Extracts valign');
     assert.equal(cellData.width, '20', 'Extracts width');
+    assert.equal(cellData.height, '30', 'Extracts height');
 
     assert.equal(cellData.backgroundcolor, '#333333', 'Extracts background-color');
     assert.equal(cellData.bordercolor, '#D91111', 'Extracts border-color');
@@ -61,13 +62,14 @@ describe('browser.tinymce.plugins.table.HelpersTest', () => {
     );
     const elements = UiFinder.findAllIn(TinyDom.body(editor), '.foo') as [ SugarElement<HTMLTableColElement>, SugarElement<HTMLTableCellElement> ];
     const cellData = Helpers.extractDataFromCellElement(editor, elements[1].dom, true, Optional.some(elements[0].dom));
-    assert.hasAllKeys(cellData, [ 'class', 'scope', 'celltype', 'halign', 'valign', 'width', 'backgroundcolor', 'bordercolor', 'borderstyle', 'borderwidth' ]);
+    assert.hasAllKeys(cellData, [ 'class', 'scope', 'celltype', 'halign', 'valign', 'width', 'height', 'backgroundcolor', 'bordercolor', 'borderstyle', 'borderwidth' ]);
     assert.equal(cellData.class, 'foo', 'Extracts class');
     assert.equal(cellData.scope, 'row', 'Extracts scope');
     assert.equal(cellData.celltype, 'td', 'Extracts celltype');
     assert.equal(cellData.halign, 'left', 'Extracts halign');
     assert.equal(cellData.valign, 'middle', 'Extracts valign');
     assert.equal(cellData.width, '20', 'Does Not Extracts width');
+    assert.equal(cellData.height, '30', 'Extracts height');
 
     assert.equal(cellData.backgroundcolor, '#333333', 'Extracts background-color');
     assert.equal(cellData.bordercolor, '#D91111', 'Extracts border-color');
@@ -89,8 +91,9 @@ describe('browser.tinymce.plugins.table.HelpersTest', () => {
     );
     const td = UiFinder.findIn<HTMLTableCellElement>(TinyDom.body(editor), 'td.foo').getOrDie();
     const cellData = Helpers.extractDataFromCellElement(editor, td.dom, true, Optional.none());
-    assert.hasAllKeys(cellData, [ 'class', 'scope', 'celltype', 'halign', 'valign', 'width', 'backgroundcolor', 'bordercolor', 'borderstyle', 'borderwidth' ]);
+    assert.hasAllKeys(cellData, [ 'class', 'scope', 'celltype', 'halign', 'valign', 'width', 'height', 'backgroundcolor', 'bordercolor', 'borderstyle', 'borderwidth' ]);
     assert.equal(cellData.width, '20px', 'Extracts width from style');
+    assert.equal(cellData.height, '30px', 'Extracts height from row');
     assert.equal(cellData.class, 'foo', 'Extracts class');
     assert.equal(cellData.celltype, 'td', 'Extracts celltype');
 
@@ -120,8 +123,9 @@ describe('browser.tinymce.plugins.table.HelpersTest', () => {
     );
     const elements = UiFinder.findAllIn(TinyDom.body(editor), '.foo') as [ SugarElement<HTMLTableColElement>, SugarElement<HTMLTableCellElement> ];
     const cellData = Helpers.extractDataFromCellElement(editor, elements[1].dom, true, Optional.some(elements[0].dom));
-    assert.hasAllKeys(cellData, [ 'class', 'scope', 'celltype', 'halign', 'valign', 'width', 'backgroundcolor', 'bordercolor', 'borderstyle', 'borderwidth' ]);
+    assert.hasAllKeys(cellData, [ 'class', 'scope', 'celltype', 'halign', 'valign', 'width', 'height', 'backgroundcolor', 'bordercolor', 'borderstyle', 'borderwidth' ]);
     assert.equal(cellData.width, '20px', 'Extracts width from style');
+    assert.equal(cellData.height, '30px', 'Extracts height from row');
     assert.equal(cellData.backgroundcolor, '#333333', 'Extracts background-color from rgb');
     assert.equal(cellData.bordercolor, '#D91111', 'Extracts border-color from rgb');
     assert.equal(cellData.class, 'foo', 'Extracts class');
@@ -181,7 +185,6 @@ describe('browser.tinymce.plugins.table.HelpersTest', () => {
     );
     const tr = UiFinder.findIn<HTMLTableRowElement>(TinyDom.body(editor), 'tr.foo').getOrDie();
     const rowData = Helpers.extractDataFromRowElement(editor, tr.dom, true);
-    assert.equal(rowData.height, '30px', 'Extracts height');
     assert.equal(rowData.class, 'foo', 'Extracts class');
     assert.equal(rowData.align, 'left', 'Extracts align');
     assert.equal(rowData.type, 'body', 'Extracts type');

--- a/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/browser/ui/TableCellDialogTest.ts
@@ -31,6 +31,8 @@ describe('browser.tinymce.plugins.table.TableCellDialogTest', () => {
 
   const generalSelectors = {
     width: 'label.tox-label:contains(Width) + input.tox-textfield',
+    height: 'label.tox-label:contains(Height) + input.tox-textfield',
+    backgroundcolor: 'label.tox-label:contains(Background color) + div>input.tox-textfield',
     celltype: 'label.tox-label:contains(Cell type) + div.tox-listboxfield > .tox-listbox',
     scope: 'label.tox-label:contains(Scope) + div.tox-listboxfield > .tox-listbox',
     halign: 'label.tox-label:contains(Horizontal align) + div.tox-listboxfield > .tox-listbox',

--- a/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
+++ b/modules/tinymce/src/plugins/table/test/ts/module/test/TableTestUtils.ts
@@ -23,8 +23,7 @@ export interface WidthData {
 const advSelectors = {
   borderwidth: 'label.tox-label:contains(Border width) + input.tox-textfield',
   borderstyle: 'label.tox-label:contains(Border style) + div.tox-listboxfield > .tox-listbox',
-  bordercolor: 'label.tox-label:contains(Border color) + div>input.tox-textfield',
-  backgroundcolor: 'label.tox-label:contains(Background color) + div>input.tox-textfield'
+  bordercolor: 'label.tox-label:contains(Border color) + div>input.tox-textfield'
 };
 
 const assertTableStructure = (editor: Editor, structure: StructAssert): void => {
@@ -118,7 +117,7 @@ const gotoGeneralTab = (): void => {
 };
 
 const gotoAdvancedTab = (): void => {
-  Mouse.clickOn(SugarBody.body(), 'div.tox-tab:contains(Advanced)');
+  Mouse.clickOn(SugarBody.body(), 'div.tox-tab:contains(Border)');
 };
 
 const setTabInputValues = (data: Record<string, any>, tabSelectors: Record<string, string>): void => {


### PR DESCRIPTION
### Background  
The main goal was to allow customization of the table context menu, as it currently contains items that are not always needed. In addition, several small adjustments were made to make the cell, row, and table properties dialogs more intuitive for users.

### Implementation  

New options were added to control which items are shown in the table context menu:

- **`table_contextmenu`**: Defines which top-level items are displayed in the table context menu (`cell`, `row`, `column`, `tableprops`, `deletetable`). By default, all items are shown.
- **`table_cell_contextmenu`**: Defines which items are displayed in the table cell submenu (`tablecellprops`, `tablemergecells`, `tablesplitcells`). By default, all items are shown.
- **`table_row_contextmenu`**: Defines which items are displayed in the table row submenu (`tableinsertrowbefore`, `tableinsertrowafter`, `tabledeleterow`, `tablerowprops`, `tablecutrow`, `tablecopyrow`, `tablepasterowbefore`, `tablepasterowafter`). By default, all items are shown.
- **`table_column_contextmenu`**: Defines which items are displayed in the table column submenu (`tableinsertcolumnbefore`, `tableinsertcolumnafter`, `tabledeletecolumn`, `tablecutcolumn`, `tablecopycolumn`, `tablepastecolumnbefore`, `tablepastecolumnafter`). By default, all items are shown.

An additional option was introduced to control the structure of the menu:

- **`table_contextmenu_flatten`**: Boolean flag (default `false`) that determines whether the table context menu should be flattened.

These options apply both to the context menu opened via right-click inside a table and to the menu opened from the table button in the toolbar.

<img width="209" height="347" alt="image" src="https://github.com/user-attachments/assets/60f5c9d4-4696-40ca-8d2c-f33b5b4bbae1" />

---

Several usability improvements were also made:

- The row height input was moved from **Row properties** to **Cell properties**, next to the width input, to make its placement more intuitive.
- The background color setting was moved from the **Advanced** tab to the **General** tab.
- The **Advanced** tab was renamed to **Border**, as it now contains only border-related settings (width, style, and color).
- The tooltip for row height was updated to clarify that, in some cases, the table height must be cleared before changing the row height. A proper fix for this behavior is planned for the future.
