### PR TITLE
Resize images that overflows the content element

### DIFF
--- a/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/tinymce/src/core/main/ts/api/OptionTypes.ts
@@ -96,6 +96,7 @@ interface BaseEditorOptions {
   deprecation_warnings?: boolean;
   directionality?: 'ltr' | 'rtl';
   doctype?: string;
+  document_content_root_class?: string;
   document_base_url?: string;
   draggable_modal?: boolean;
   editable_class?: string;
@@ -296,6 +297,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   custom_colors: boolean;
   default_font_stack: string[];
   document_base_url: string;
+  document_content_root_class: string;
   init_content_sync: boolean;
   draggable_modal: boolean;
   editable_class: string;

--- a/modules/tinymce/src/core/main/ts/api/Options.ts
+++ b/modules/tinymce/src/core/main/ts/api/Options.ts
@@ -114,6 +114,11 @@ const register = (editor: Editor): void => {
     default: ''
   });
 
+  registerOption('document_content_root_class', {
+    processor: 'string',
+    default: 'mce-content-body'
+  });
+
   registerOption('content_security_policy', {
     processor: 'string',
     default: ''
@@ -889,6 +894,7 @@ const getDocType = option('doctype');
 const getDocumentBaseUrl = option('document_base_url');
 const getBodyId = option('body_id');
 const getBodyClass = option('body_class');
+const getDocumentContentRootClass = option('document_content_root_class');
 const getContentSecurityPolicy = option('content_security_policy');
 const shouldPutBrInPre = option('br_in_pre');
 const getForcedRootBlock = option('forced_root_block');
@@ -1001,6 +1007,7 @@ export {
   getDocumentBaseUrl,
   getBodyId,
   getBodyClass,
+  getDocumentContentRootClass,
   getContentSecurityPolicy,
   shouldPutBrInPre,
   getForcedRootBlock,

--- a/modules/tinymce/src/core/main/ts/paste/Clipboard.ts
+++ b/modules/tinymce/src/core/main/ts/paste/Clipboard.ts
@@ -30,6 +30,11 @@ export interface ClipboardContents {
 
 const defaultMaxImageWidthPx = 300;
 
+const getContentRootSelector = (editor: Editor): string => {
+  const contentRootClass = Options.getDocumentContentRootClass(editor);
+  return contentRootClass.startsWith('.') ? contentRootClass : `.${contentRootClass}`;
+};
+
 const uniqueId = PasteUtils.createIdGenerator('mceclip');
 
 const createPasteDataTransfer = (html: string): DataTransfer => {
@@ -133,8 +138,8 @@ const pasteImage = (editor: Editor, imageItem: FileResult): void => {
     const img = new Image();
         img.src = blobInfo.blobUri();
         img.onload = () => {
-          const contentBodyElement = editor.dom.select('.mce-content-body')[0].children[0];
-          const computedStyles = contentBodyElement ? window.getComputedStyle(contentBodyElement) : null;
+          const contentRootElement = editor.dom.select(getContentRootSelector(editor))[0];
+          const computedStyles = contentRootElement ? window.getComputedStyle(contentRootElement) : null;
           const maxImageWidth = computedStyles ? parseInt(computedStyles.width) - parseInt(computedStyles.paddingLeft) - parseInt(computedStyles.paddingRight) : defaultMaxImageWidthPx;
           const imageWidth = Math.min(img.naturalWidth, maxImageWidth)
           pasteHtml(editor, `<img src="${ blobInfo.blobUri() }" width="${ imageWidth }px">`, false, true);

--- a/modules/tinymce/src/plugins/quickbars/main/ts/insert/Actions.ts
+++ b/modules/tinymce/src/plugins/quickbars/main/ts/insert/Actions.ts
@@ -1,8 +1,14 @@
 import { Id } from '@ephox/katamari';
 
 import Editor from 'tinymce/core/api/Editor';
+import * as Options from 'tinymce/core/api/Options';
 
 const defaultMaxImageWidthPx = 300;
+
+const getContentRootSelector = (editor: Editor): string => {
+  const contentRootClass = Options.getDocumentContentRootClass(editor);
+  return contentRootClass.startsWith('.') ? contentRootClass : `.${contentRootClass}`;
+};
 
 const insertTable = (editor: Editor, columns: number, rows: number): void => {
   editor.execCommand('mceInsertTable', false, { rows, columns });
@@ -17,8 +23,9 @@ const insertBlob = (editor: Editor, base64: string, blob: Blob): void => {
   img.src = blobInfo.blobUri();
 
   img.onload = () => {
-    const contentBodyElement = editor.dom.select('.mce-content-body')[0];
-    const maxImageWidth = contentBodyElement ? parseInt(window.getComputedStyle(contentBodyElement).width) : defaultMaxImageWidthPx;
+    const contentRootElement = editor.dom.select(getContentRootSelector(editor))[0];
+    const computedStyles = contentRootElement ? window.getComputedStyle(contentRootElement) : null;
+    const maxImageWidth = computedStyles ? parseInt(computedStyles.width) - parseInt(computedStyles.paddingLeft) - parseInt(computedStyles.paddingRight) : defaultMaxImageWidthPx;
 
     editor.insertContent(editor.dom.createHTML('img', { src: blobInfo.blobUri(), width: `${Math.min(img.naturalWidth, maxImageWidth)}px`}));
   };


### PR DESCRIPTION
Wide images on copy paste were fixed, but not images that are inserted using dialog. Additionaly, a new option was added `document_content_root_class`, that specifies which element is the root content element, so we can calculate the max image width from it.