### PR TITLE
disallow dots and colons in anchor ID validation

### DIFF
--- a/modules/tinymce/src/plugins/anchor/main/ts/core/Anchor.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/core/Anchor.ts
@@ -18,7 +18,7 @@ const removeEmptyNamedAnchorsInSelection = (editor: Editor): void => {
 
 const isValidId = (id: string): boolean =>
   // Follows HTML4 rules: https://www.w3.org/TR/html401/types.html#type-id
-  /^[A-Za-z][A-Za-z0-9\-:._]*$/.test(id);
+  /^[A-Za-z][A-Za-z0-9\-_]*$/.test(id);
 
 const getNamedAnchor = (editor: Editor): HTMLAnchorElement | null =>
   editor.dom.getParent<HTMLAnchorElement>(editor.selection.getStart(), Utils.namedAnchorSelector);

--- a/modules/tinymce/src/plugins/anchor/main/ts/ui/Dialog.ts
+++ b/modules/tinymce/src/plugins/anchor/main/ts/ui/Dialog.ts
@@ -6,7 +6,7 @@ import I18n from "tinymce/core/api/util/I18n";
 const insertAnchor = (editor: Editor, newId: string): boolean => {
   if (!Anchor.isValidId(newId)) {
     editor.windowManager.alert(
-      'ID should start with a letter, followed only by letters, numbers, dashes, dots, colons or underscores.'
+      'ID should start with a letter, followed only by letters, numbers, dashes or underscores.'
     );
     return false;
   } else {


### PR DESCRIPTION
This PR ixes anchor ID validation to match the actual allowed characters and prevent broken anchor navigation.