### PR TITLE
Update table context menu

### DIFF
--- a/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
@@ -125,10 +125,9 @@ export default (): void => {
     toolbar: 'undo redo sidebar1 fontsizeinput | bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | align lineheight fontsize fontfamily blocks styles insertfile | styles | ' +
     'bullist numlist outdent indent | link image | print preview media | forecolor backcolor emoticons table codesample code language | ltr rtl',
     contextmenu: 'link linkchecker image table lists configurepermanentpen',
-    table_contextmenu: [ 'cell', 'row', 'tableprops', 'deletetable' ],
+    table_contextmenu: [ '|', 'tablecellprops', 'tablerowprops', 'tableprops', 'deletetable', '|', 'tablemergecells', 'tablesplitcells', '|',
+      'tableinsertrowbefore', 'tableinsertrowafter', 'tabledeleterow', '|', 'tableinsertcolumnbefore', 'tableinsertcolumnafter', 'tabledeletecolumn' ],
     table_contextmenu_flatten: true,
-    table_cell_contextmenu: [ 'tablecellprops', 'tablemergecells', 'tablesplitcells' ],
-    table_row_contextmenu: [ 'tablerowprops' ],
 
     // Multiple toolbar array
     // toolbar: ['undo redo sidebar1 align fontsize insertfile | fontfamily blocks styles insertfile | styles | bold italic',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Buttons.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Buttons.ts
@@ -47,9 +47,9 @@ const getFilteredCellMenuItems = (editor: Editor): string => {
 
 const getTableMenuItems = (editor: Editor): string => {
   const menu = 'inserttable | cell row column | advtablesort | tableprops deletetable';
-  const filteredMenu = Options.isTableContextMenuSet(editor) ?
-    filterContextMenu(menu, [ 'inserttable', ...Options.getTableContextMenu(editor) ]) :
-    menu;
+  const contextItems = Options.getTableContextMenu(editor);
+  const tableContextMenu = contextItems.length > 0 ? [ 'inserttable', ...contextItems ].join(' ') : '';
+  const filteredMenu = Options.isTableContextMenuSet(editor) ? tableContextMenu : menu;
 
   if (Options.isTableContextMenuFlatten(editor) && filteredMenu.length > 0) {
     return flattenContextMenu(filteredMenu, {

--- a/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/MenuItems.ts
@@ -257,7 +257,7 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets): void 
       // context menu fires before node change, so check the selection here first
       selectionTargets.resetTargets();
       // ignoring element since it's monitored elsewhere
-      const menu = selectionTargets.targets().fold(Fun.constant(''), (targets) => {
+      const defaultMenu = selectionTargets.targets().fold(Fun.constant(''), (targets) => {
         // If clicking in a caption, then we shouldn't show the cell/row/column options
         if (SugarNode.name(targets.element) === 'caption') {
           return 'tableprops deletetable';
@@ -265,7 +265,8 @@ const addMenuItems = (editor: Editor, selectionTargets: SelectionTargets): void 
           return 'cell row column | advtablesort | tableprops deletetable';
         }
       });
-      const filteredMenu = Options.isTableContextMenuSet(editor) ? filterContextMenu(menu, Options.getTableContextMenu(editor)) : menu;
+      const tableContextMenu = Options.getTableContextMenu(editor).join(' ');
+      const filteredMenu = Options.isTableContextMenuSet(editor) ? tableContextMenu : defaultMenu;
       if (Options.isTableContextMenuFlatten(editor) && filteredMenu.length > 0) {
         return flattenContextMenu(filteredMenu, {
           cell: filteredCellMenuItems,

--- a/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/UiUtils.ts
@@ -120,12 +120,34 @@ const filterContextMenu = (menu: string, allowed: string[]): string => {
     return '';
   }
 
-  const allowedSet = new Set(allowed);
-  const filteredGroups = menu.split('|')
-    .map((group) => group.trim())
-    .map((group) => group.length === 0 ? [] : group.split(/\s+/).filter((item) => allowedSet.has(item)))
-    .filter((items) => items.length > 0)
-    .map((items) => items.join(' '));
+  const menuItems = Arr.bind(menu.split('|'), (group) =>
+    group.trim().split(/\s+/).filter((item) => item.length > 0)
+  );
+  const validItems = new Set(menuItems);
+
+  const groups: string[][] = [];
+  let current: string[] = [];
+
+  Arr.each(allowed, (item) => {
+    if (item === '|') {
+      if (current.length > 0) {
+        groups.push(current);
+        current = [];
+      } else {
+        groups.push([]);
+      }
+    } else if (validItems.has(item)) {
+      current.push(item);
+    }
+  });
+
+  if (current.length > 0) {
+    groups.push(current);
+  }
+
+  const filteredGroups = Arr.bind(groups, (group) =>
+    group.length > 0 ? [ group.join(' ') ] : []
+  );
 
   return filteredGroups.join(' | ');
 };

--- a/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/api/Options.ts
@@ -428,6 +428,101 @@ const getMenus = (editor: Editor): Record<string, { title: string; items: string
   return Obj.map(menu, (menu) => ({ ...menu, items: menu.items }));
 };
 
+const filterContextMenu = (menu: string, allowed: string[]): string => {
+  if (allowed.length === 0) {
+    return '';
+  }
+
+  const allowedSet = new Set(allowed);
+  const filteredGroups = menu.split('|')
+    .map((group) => group.trim())
+    .map((group) => group.length === 0 ? [] : group.split(/\s+/).filter((item) => allowedSet.has(item)))
+    .filter((items) => items.length > 0)
+    .map((items) => items.join(' '));
+
+  return filteredGroups.join(' | ');
+};
+
+const flattenContextMenu = (menu: string, replacements: Record<string, string>): string => {
+  const groups = menu.split('|')
+    .map((group) => group.trim())
+    .filter((group) => group.length > 0);
+
+  const flattened: string[] = [];
+  const addGroup = (items: string[]) => {
+    if (items.length > 0) {
+      flattened.push(items.join(' '));
+    }
+  };
+
+  Arr.each(groups, (group) => {
+    const tokens = group.split(/\s+/).filter((token) => token.length > 0);
+    let current: string[] = [];
+
+    Arr.each(tokens, (token) => {
+      const replacement = replacements[token];
+      if (replacement === undefined) {
+        current.push(token);
+      } else if (replacement.length === 0) {
+        return;
+      } else {
+        const replacementGroups = replacement.split('|')
+          .map((repGroup) => repGroup.trim())
+          .filter((repGroup) => repGroup.length > 0);
+
+        if (replacementGroups.length === 1) {
+          current = current.concat(replacementGroups[0].split(/\s+/).filter((item) => item.length > 0));
+        } else {
+          addGroup(current);
+          current = [];
+          Arr.each(replacementGroups, (repGroup) => {
+            addGroup(repGroup.split(/\s+/).filter((item) => item.length > 0));
+          });
+        }
+      }
+    });
+
+    addGroup(current);
+  });
+
+  return flattened.join(' | ');
+};
+
+const getFilteredTableMenuItems = (editor: Editor, menu: string): string => {
+  if (!editor.options.isRegistered('table_contextmenu')) {
+    return menu;
+  }
+
+  const isTableContextMenuSet = editor.options.isSet('table_contextmenu');
+  const contextItems = editor.options.get<string[]>('table_contextmenu') ?? [];
+  const tableContextMenu = contextItems.length > 0 ? [ 'inserttable', ...contextItems ] : [];
+  const filteredMenu = isTableContextMenuSet ? tableContextMenu.join(' ') : menu;
+
+  if (!editor.options.get('table_contextmenu_flatten') || filteredMenu.length === 0) {
+    return filteredMenu;
+  }
+
+  const rowMenuItems = 'tableinsertrowbefore tableinsertrowafter tabledeleterow tablerowprops | tablecutrow tablecopyrow tablepasterowbefore tablepasterowafter';
+  const columnMenuItems = 'tableinsertcolumnbefore tableinsertcolumnafter tabledeletecolumn | tablecutcolumn tablecopycolumn tablepastecolumnbefore tablepastecolumnafter';
+  const cellMenuItems = 'tablecellprops tablemergecells tablesplitcells';
+
+  const filteredRowMenuItems = editor.options.isSet('table_row_contextmenu') ?
+    filterContextMenu(rowMenuItems, editor.options.get<string[]>('table_row_contextmenu') ?? []) :
+    rowMenuItems;
+  const filteredColumnMenuItems = editor.options.isSet('table_column_contextmenu') ?
+    filterContextMenu(columnMenuItems, editor.options.get<string[]>('table_column_contextmenu') ?? []) :
+    columnMenuItems;
+  const filteredCellMenuItems = editor.options.isSet('table_cell_contextmenu') ?
+    filterContextMenu(cellMenuItems, editor.options.get<string[]>('table_cell_contextmenu') ?? []) :
+    cellMenuItems;
+
+  return flattenContextMenu(filteredMenu, {
+    cell: filteredCellMenuItems,
+    row: filteredRowMenuItems,
+    column: filteredColumnMenuItems
+  });
+};
+
 export {
   register,
   getSkinUrl,
@@ -479,5 +574,6 @@ export {
   getPasteAsText,
   getSidebarShow,
   useHelpAccessibility,
-  getDefaultFontStack
+  getDefaultFontStack,
+  getFilteredTableMenuItems
 };

--- a/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
+++ b/modules/tinymce/src/themes/silver/main/ts/ui/menus/menubar/Integration.ts
@@ -73,7 +73,8 @@ const identifyMenus = (editor: Editor, registry: MenuRegistry): MenubarItemSpec[
 
   const menus: MenubarItemSpec[] = Arr.map(validMenus, (menuName) => {
     const menuData = rawMenuData[menuName];
-    return make({ title: menuData.title, items: parseItemsString(menuData.items) }, registry, editor);
+    const items = menuName === 'table' ? parseItemsString(Options.getFilteredTableMenuItems(editor, menuData.items)) : parseItemsString(menuData.items);
+    return make({ title: menuData.title, items }, registry, editor);
   });
 
   return Arr.filter(menus, (menu) => {


### PR DESCRIPTION
- Allow `table_contextmenu` to list actual menu items directly (not just `cell/row/column`) and support `|` separators.
- Preserve `inserttable` in the table menu button and menubar Table menu when `table_contextmenu` is set.
- Enable `|` dividers within `table_cell_contextmenu`, `table_row_contextmenu`, and `table_column_contextmenu`.