### PR TITLE
Add option to cross out a cell

### DIFF
--- a/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
+++ b/modules/tinymce/src/core/demo/ts/demo/FullDemo.ts
@@ -84,7 +84,7 @@ export default (): void => {
     ],
     importcss_append: true,
     // init_content_sync: true,
-    height: 400,
+    height: 800,
     image_advtab: true,
     file_picker_callback: (callback, _value, meta) => {
       if (meta.fieldname === 'poster') {

--- a/modules/tinymce/src/plugins/table/main/ts/api/Options.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/api/Options.ts
@@ -9,7 +9,7 @@ import { UserListItem, UserListValue } from '../ui/UiUtils';
 
 const defaultTableToolbar = 'tableprops tabledelete | tableinsertrowbefore tableinsertrowafter tabledeleterow | tableinsertcolbefore tableinsertcolafter tabledeletecol';
 
-const defaultTableCellInputs = 'width height celltype scope halign valign backgroundcolor class';
+const defaultTableCellInputs = 'width height celltype scope halign valign backgroundcolor crossedout class';
 const defaultTableRowInputs = 'type align backgroundcolor class';
 const defaultTableInputs = 'width height cellspacing cellpadding backgroundcolor caption align class';
 

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
@@ -52,7 +52,7 @@ const updateSimpleProps = (modifier: DomModifier, colModifier: DomModifier, data
     if (data.crossedout) {
       modifier.setStyle(
         'background-image',
-        'url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 100 100\' preserveAspectRatio=\'none\'><line x1=\'0\' y1=\'100\' x2=\'100\' y2=\'0\' stroke=\'%23000\' stroke-width=\'1\' vector-effect=\'non-scaling-stroke\'/></svg>")'
+        'url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 1 1\' preserveAspectRatio=\'none\'><line x1=\'0\' y1=\'1\' x2=\'1\' y2=\'0\' stroke=\'%23000\' stroke-width=\'1\' vector-effect=\'non-scaling-stroke\'/></svg>")'
       );
       modifier.setStyle('background-repeat', 'no-repeat');
       modifier.setStyle('background-size', '100% 100%');

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialog.ts
@@ -48,6 +48,28 @@ const updateSimpleProps = (modifier: DomModifier, colModifier: DomModifier, data
   if (shouldUpdate('width')) {
     colModifier.setStyle('width', Utils.addPxSuffix(data.width));
   }
+  if (shouldUpdate('crossedout')) {
+    if (data.crossedout) {
+      modifier.setStyle(
+        'background-image',
+        'url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\' viewBox=\'0 0 100 100\' preserveAspectRatio=\'none\'><line x1=\'0\' y1=\'100\' x2=\'100\' y2=\'0\' stroke=\'%23000\' stroke-width=\'1\' vector-effect=\'non-scaling-stroke\'/></svg>")'
+      );
+      modifier.setStyle('background-repeat', 'no-repeat');
+      modifier.setStyle('background-size', '100% 100%');
+      modifier.setStyle('background-position', 'left top');
+      modifier.setStyle('background-origin', 'border-box');
+      modifier.setStyle('background-clip', 'border-box');
+      modifier.setAttrib('data-mce-crossedout', '1');
+    } else {
+      modifier.setStyle('background-image', '');
+      modifier.setStyle('background-repeat', '');
+      modifier.setStyle('background-size', '');
+      modifier.setStyle('background-position', '');
+      modifier.setStyle('background-origin', '');
+      modifier.setStyle('background-clip', '');
+      modifier.setAttrib('data-mce-crossedout', '');
+    }
+  }
 };
 
 const updateAdvancedProps = (modifier: DomModifier, data: Required<CellData>, shouldUpdate: (key: string) => boolean): void => {
@@ -79,6 +101,10 @@ const applyStyleData = (editor: Editor, cells: SelectedCell[], data: CellData, w
 
     if (Options.hasAdvancedCellTab(editor)) {
       updateAdvancedProps(modifier, data as Required<CellData>, shouldOverrideCurrentValue);
+    }
+
+    if (shouldOverrideCurrentValue('crossedout') && wasChanged('crossedout') && data.crossedout) {
+      editor.dom.setHTML(cellElm, '');
     }
 
     if (shouldOverrideCurrentValue('height')) {

--- a/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/CellDialogGeneralTab.ts
@@ -36,6 +36,19 @@ const children: Dialog.BodyComponentSpec[] = [
     tooltip: 'Background color of the cell.'
   },
   {
+    type: 'label',
+    label: 'Crossed out',
+    name: 'crossedout',
+    tooltip: 'Cross out the selected cell.',
+    items: [
+      {
+        type: 'checkbox',
+        name: 'crossedout',
+        label: 'Cross out the cell'
+      }
+    ]
+  },
+  {
     name: 'celltype',
     type: 'listbox',
     label: 'Cell type',

--- a/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
+++ b/modules/tinymce/src/plugins/table/main/ts/ui/Helpers.ts
@@ -59,6 +59,7 @@ export type CellData = {
   readonly class: string;
   readonly halign: string;
   readonly valign: string;
+  readonly crossedout: boolean;
   readonly borderwidth?: string;
   readonly borderstyle?: string;
   readonly bordercolor?: string;
@@ -78,11 +79,11 @@ const extractAdvancedStyles = (elm: Node): AdvancedStyles => {
   };
 };
 
-const getSharedValues = <T extends Record<string, string>>(data: T[]): T => {
+const getSharedValues = <T extends Record<string, string | boolean>>(data: T[]): T => {
   // TODO surely there's a better way to do this??
   // Mutates baseData to return an object that contains only the values
   // that were the same across all objects in data
-  const baseData: Record<string, string> = data[0];
+  const baseData: Record<string, string | boolean> = data[0];
   const comparisonData = data.slice(1);
 
   Arr.each(comparisonData, (items) => {
@@ -91,7 +92,13 @@ const getSharedValues = <T extends Record<string, string>>(data: T[]): T => {
         const comparisonValue = baseData[key];
         if (comparisonValue !== '' && key === itemKey) {
           if (comparisonValue !== itemValue) {
-            baseData[key] = key === 'class' ? 'mce-no-match' : '';
+            if (key === 'class') {
+              baseData[key] = 'mce-no-match';
+            } else if (Type.isBoolean(comparisonValue)) {
+              baseData[key] = false;
+            } else {
+              baseData[key] = '';
+            }
           }
         }
       });
@@ -220,6 +227,7 @@ const extractDataFromCellElement = (editor: Editor, cell: HTMLTableCellElement, 
   const rowElm = cell.parentElement;
 
   const getStyle = (element: HTMLElement, style: string) => dom.getStyle(element, style) || dom.getAttrib(element, style);
+  const isCrossedOut = dom.getAttrib(cell, 'data-mce-crossedout') === '1';
 
   return {
     width: getStyle(colElm, 'width'),
@@ -229,6 +237,7 @@ const extractDataFromCellElement = (editor: Editor, cell: HTMLTableCellElement, 
     class: dom.getAttrib(cell, 'class', ''),
     halign: getHAlignment(editor, cell),
     valign: getVAlignment(editor, cell),
+    crossedout: isCrossedOut,
     ...(hasAdvancedCellTab ? extractAdvancedStyles(cell) : {})
   };
 };


### PR DESCRIPTION
### Background
Users wanted the ability to cross out table cells, which was not previously supported.

### Implementation
Added an option in the **Cell properties** dialog to mark a cell as crossed out. This option:
- Applies CSS styles to visually cross out the cell
- Adds a `data-mce-crossedout="1"` attribute to indicate the state and control whether the checkbox is checked

Result:
<img width="1096" height="244" alt="image" src="https://github.com/user-attachments/assets/d759c3ff-bde9-4466-bc8a-99a4ee171bb2" />
<img width="525" height="651" alt="image" src="https://github.com/user-attachments/assets/a7d2cee5-68d6-49e6-a4d1-379e4a2f648b" />
